### PR TITLE
Redesign UI: density rail, time buckets, sticky header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,27 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import DatePicker from './components/DatePicker'
-import EventCard from './components/EventCard'
+import DensityRail from './components/DensityRail'
+import AllDayStrip from './components/AllDayStrip'
+import BucketSection from './components/BucketSection'
+import { partitionEvents } from './lib/eventTime'
 
 function toLocalDateString(date) {
   return date.toLocaleDateString('en-CA') // YYYY-MM-DD in local time
+}
+
+const BUCKETS = [
+  { id: 'morning', label: 'Morning', startHour: 5, endHour: 12 },
+  { id: 'afternoon', label: 'Afternoon', startHour: 12, endHour: 17 },
+  { id: 'evening', label: 'Evening', startHour: 17, endHour: 21 },
+  { id: 'night', label: 'Late Night', startHour: 21, endHour: 29 }, // wraps past midnight
+]
+
+function bucketForHour(hour) {
+  for (const b of BUCKETS) {
+    if (hour >= b.startHour && hour < b.endHour) return b.id
+  }
+  if (hour < 5) return 'night'
+  return 'morning'
 }
 
 export default function App() {
@@ -25,34 +43,50 @@ export default function App() {
       .finally(() => setLoading(false))
   }, [selectedDate])
 
+  const partition = useMemo(
+    () => partitionEvents(events, selectedDate),
+    [events, selectedDate],
+  )
+
+  const handleJumpToHour = (hour) => {
+    const el = document.getElementById(bucketForHour(hour))
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-2xl mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-1">What's Up Madison</h1>
-        <p className="text-gray-500 mb-6 text-sm">Events in Madison, WI</p>
+      <div className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-3">
+          <h1 className="text-lg font-bold text-gray-900">What's Up Madison</h1>
+          <DatePicker value={selectedDate} onChange={setSelectedDate} />
+        </div>
+      </div>
 
-        <DatePicker value={selectedDate} onChange={setSelectedDate} />
-
-        <div className="mt-6">
-          {loading && (
-            <p className="text-gray-400 text-sm">Loading…</p>
-          )}
-          {error && (
-            <p className="text-red-500 text-sm">Error: {error}</p>
-          )}
+      <div className="max-w-7xl mx-auto px-4 pt-4 pb-6">
+        <div>
+          {loading && <p className="text-gray-400 text-sm">Loading…</p>}
+          {error && <p className="text-red-500 text-sm">Error: {error}</p>}
           {!loading && !error && events.length === 0 && (
             <p className="text-gray-400 text-sm">No events found for this date.</p>
           )}
           {!loading && !error && events.length > 0 && (
             <>
-              <p className="text-gray-500 text-xs mb-4">
+              <p className="text-gray-500 text-xs mb-2">
                 {events.length} event{events.length !== 1 ? 's' : ''}
               </p>
-              <div className="space-y-3">
-                {events.map((event) => (
-                  <EventCard key={event.id} event={event} />
-                ))}
-              </div>
+              <DensityRail
+                hourCounts={partition.hourCounts}
+                onJumpToHour={handleJumpToHour}
+              />
+              <AllDayStrip events={partition.allday} />
+              {BUCKETS.map((b) => (
+                <BucketSection
+                  key={b.id}
+                  id={b.id}
+                  label={b.label}
+                  events={partition[b.id]}
+                />
+              ))}
             </>
           )}
         </div>

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,0 +1,50 @@
+export default function AllDayStrip({ events }) {
+  if (!events || events.length === 0) return null
+
+  return (
+    <section id="allday" className="scroll-mt-32 mt-4">
+      <h2 className="sticky top-32 z-10 bg-emerald-50 border border-emerald-200 text-emerald-900 rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between">
+        <span>All Day</span>
+        <span className="text-xs font-normal opacity-70">
+          {events.length} event{events.length === 1 ? '' : 's'}
+        </span>
+      </h2>
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+        {events.map((event) => (
+          <AllDayCard key={event.id} event={event} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function AllDayCard({ event }) {
+  const primary = event.sources?.[0]
+  const Inner = (
+    <>
+      <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2">
+        {event.title}
+      </h3>
+      {event.venue_name && (
+        <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
+      )}
+    </>
+  )
+  if (primary?.source_url) {
+    return (
+      <a
+        href={primary.source_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm hover:border-emerald-300 hover:shadow transition"
+      >
+        {Inner}
+      </a>
+    )
+  }
+  return (
+    <div className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm">
+      {Inner}
+    </div>
+  )
+}

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -1,0 +1,32 @@
+import EventCard from './EventCard'
+
+const TINTS = {
+  morning: 'bg-amber-50 border-amber-200 text-amber-900',
+  afternoon: 'bg-sky-50 border-sky-200 text-sky-900',
+  evening: 'bg-indigo-50 border-indigo-200 text-indigo-900',
+  night: 'bg-slate-100 border-slate-300 text-slate-800',
+}
+
+export default function BucketSection({ id, label, events }) {
+  if (!events || events.length === 0) return null
+
+  const tint = TINTS[id] ?? 'bg-gray-100 border-gray-200 text-gray-800'
+
+  return (
+    <section id={id} className="scroll-mt-32 mt-6 first:mt-2">
+      <h2
+        className={`sticky top-32 z-10 ${tint} border rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between`}
+      >
+        <span>{label}</span>
+        <span className="text-xs font-normal opacity-70">
+          {events.length} event{events.length === 1 ? '' : 's'}
+        </span>
+      </h2>
+      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+        {events.map((event) => (
+          <EventCard key={event.id} event={event} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/DatePicker.jsx
+++ b/frontend/src/components/DatePicker.jsx
@@ -1,16 +1,33 @@
 export default function DatePicker({ value, onChange }) {
+  function shift(days) {
+    const d = new Date(value + 'T12:00:00')
+    d.setDate(d.getDate() + days)
+    onChange(d.toLocaleDateString('en-CA'))
+  }
+
   return (
-    <div className="flex items-center gap-3">
-      <label htmlFor="date-input" className="text-sm font-medium text-gray-700">
-        Date
-      </label>
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => shift(-1)}
+        className="px-2 py-1 text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
+      >
+        ← <span className="hidden sm:inline">Yesterday</span>
+      </button>
       <input
         id="date-input"
         type="date"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="border border-gray-300 rounded-md px-3 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="border border-gray-300 rounded-md px-2 py-1 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
       />
+      <button
+        type="button"
+        onClick={() => shift(1)}
+        className="px-2 py-1 text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
+      >
+        <span className="hidden sm:inline">Tomorrow</span> →
+      </button>
     </div>
   )
 }

--- a/frontend/src/components/DensityRail.jsx
+++ b/frontend/src/components/DensityRail.jsx
@@ -1,0 +1,73 @@
+const HOUR_TICKS = [
+  { hour: 5, label: '5a' },
+  { hour: 8, label: '8a' },
+  { hour: 12, label: '12p' },
+  { hour: 15, label: '3p' },
+  { hour: 18, label: '6p' },
+  { hour: 21, label: '9p' },
+  { hour: 1, label: '1a' },
+]
+
+const ORDER = [...Array(19).keys()].map((i) => i + 5).concat([0, 1, 2, 3, 4])
+
+export default function DensityRail({ hourCounts, onJumpToHour }) {
+  const max = Math.max(1, ...hourCounts)
+  const total = hourCounts.reduce((a, b) => a + b, 0)
+  if (total === 0) return null
+
+  return (
+    <div className="sticky top-12 z-20 bg-gray-50/90 backdrop-blur border-b border-gray-200 -mx-4 px-4 py-2">
+      <div className="relative flex gap-px h-12">
+        {ORDER.map((h) => {
+          const count = hourCounts[h]
+          const heightPct = count === 0 ? 0 : (count / max) * 100
+          const isEmpty = count === 0
+          return (
+            <button
+              key={h}
+              type="button"
+              onClick={() => onJumpToHour(h)}
+              disabled={isEmpty}
+              aria-label={`${count} event${count === 1 ? '' : 's'} starting at ${formatHourLabel(h)}`}
+              title={`${formatHourLabel(h)}: ${count} event${count === 1 ? '' : 's'}`}
+              className={`flex-1 relative h-full min-w-0 ${
+                isEmpty ? 'cursor-default' : 'cursor-pointer group'
+              }`}
+            >
+              <div
+                className={`absolute bottom-0 left-0 right-0 rounded-t-sm transition-colors ${
+                  isEmpty
+                    ? 'bg-gray-200'
+                    : 'bg-blue-400 group-hover:bg-blue-500'
+                }`}
+                style={{ height: isEmpty ? '1px' : `${Math.max(6, heightPct)}%` }}
+              />
+            </button>
+          )
+        })}
+      </div>
+      <div className="relative h-3 mt-1 text-[10px] text-gray-400">
+        {HOUR_TICKS.map((tick) => {
+          const idx = ORDER.indexOf(tick.hour)
+          const leftPct = (idx / ORDER.length) * 100 + 0.5 / ORDER.length * 100
+          return (
+            <span
+              key={tick.hour}
+              className="absolute -translate-x-1/2"
+              style={{ left: `${leftPct}%` }}
+            >
+              {tick.label}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function formatHourLabel(h) {
+  if (h === 0) return '12a'
+  if (h === 12) return '12p'
+  if (h < 12) return `${h}a`
+  return `${h - 12}p`
+}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,27 +1,30 @@
-function formatTime(isoString) {
-  const date = new Date(isoString)
-  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: 'America/Chicago' })
-}
-
-function formatTimeRange(start, end) {
-  if (!end) return formatTime(start)
-  return `${formatTime(start)} – ${formatTime(end)}`
-}
+import { formatTimeRange } from '../lib/eventTime'
 
 export default function EventCard({ event }) {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="text-xs text-gray-400 mb-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
-          <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
-          {event.venue_name && (
-            <p className="text-sm text-gray-500 mt-0.5">{event.venue_name}</p>
-          )}
+    <div className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col h-full">
+      <p className="text-xs text-gray-400 mb-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+      <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
+      {event.venue_name && (
+        <p className="text-sm text-gray-500 mt-0.5">{event.venue_name}</p>
+      )}
+      {event.description && (
+        <p className="text-sm text-gray-600 mt-2 line-clamp-2">{event.description}</p>
+      )}
+      {event.categories?.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {event.categories.map((c) => (
+            <span
+              key={c}
+              className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+            >
+              {c}
+            </span>
+          ))}
         </div>
-      </div>
+      )}
       {event.sources && event.sources.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
+        <div className="mt-auto pt-2 flex flex-wrap gap-2">
           {event.sources.map((s) => (
             <a
               key={s.source_name}

--- a/frontend/src/lib/eventTime.js
+++ b/frontend/src/lib/eventTime.js
@@ -1,0 +1,104 @@
+const TZ = 'America/Chicago'
+
+const timeFmt = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZone: TZ,
+})
+
+const hourFmt = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  hour12: false,
+  timeZone: TZ,
+})
+
+const ymdFmt = new Intl.DateTimeFormat('en-CA', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  timeZone: TZ,
+})
+
+const minuteFmt = new Intl.DateTimeFormat('en-US', {
+  minute: '2-digit',
+  timeZone: TZ,
+})
+
+export function formatTime(iso) {
+  return timeFmt.format(new Date(iso))
+}
+
+export function formatTimeRange(start, end) {
+  if (!end) return formatTime(start)
+  return `${formatTime(start)} – ${formatTime(end)}`
+}
+
+export function localHour(iso) {
+  const h = parseInt(hourFmt.format(new Date(iso)), 10)
+  return h === 24 ? 0 : h
+}
+
+function localYMD(iso) {
+  return ymdFmt.format(new Date(iso))
+}
+
+function isLocalMidnight(iso) {
+  const d = new Date(iso)
+  return parseInt(hourFmt.format(d), 10) % 24 === 0 && parseInt(minuteFmt.format(d), 10) === 0
+}
+
+export function isAllDay(event, requestedDate) {
+  if (!event.start_at) return false
+
+  // Multi-day event that fully spans the requested day (started before, ends after).
+  if (event.end_at && requestedDate) {
+    const startBefore = localYMD(event.start_at) < requestedDate
+    const endAfter = localYMD(event.end_at) > requestedDate
+    if (startBefore && endAfter) return true
+  }
+
+  // Otherwise the canonical all-day shape: midnight → midnight, ≥ 24h.
+  if (!isLocalMidnight(event.start_at)) return false
+  if (!event.end_at) return true
+  if (event.end_at === event.start_at) return true
+  if (!isLocalMidnight(event.end_at)) return false
+  const ms = new Date(event.end_at) - new Date(event.start_at)
+  return ms >= 24 * 60 * 60 * 1000
+}
+
+export function bucketOf(event) {
+  const h = localHour(event.start_at)
+  if (h >= 5 && h < 12) return 'morning'
+  if (h >= 12 && h < 17) return 'afternoon'
+  if (h >= 17 && h < 21) return 'evening'
+  return 'night'
+}
+
+export function partitionEvents(events, requestedDate) {
+  const groups = { allday: [], morning: [], afternoon: [], evening: [], night: [] }
+  const hourCounts = new Array(24).fill(0)
+
+  for (const event of events) {
+    if (isAllDay(event, requestedDate)) {
+      groups.allday.push(event)
+      continue
+    }
+
+    if (requestedDate && localYMD(event.start_at) < requestedDate) {
+      // Night-crossing from previous day (ends before 3am on requested date): skip entirely.
+      // It belongs to the previous day's night bucket, not this day.
+      if (event.end_at && localYMD(event.end_at) === requestedDate && localHour(event.end_at) < 3) {
+        continue
+      }
+      // Multi-day event still ongoing: show in all-day strip.
+      groups.allday.push(event)
+      continue
+    }
+
+    const hour = localHour(event.start_at)
+    hourCounts[hour] += 1
+    groups[bucketOf(event)].push(event)
+  }
+
+  return { ...groups, hourCounts }
+}


### PR DESCRIPTION
## Summary

- **Density rail**: sticky 24-bar hourly event visualizer at the top of the page; clicking a bar smooth-scrolls to the corresponding time bucket
- **Time buckets**: events partitioned into Morning / Afternoon / Evening / Late Night sections with tinted sticky headers and a responsive 1–4 column card grid
- **All-day strip**: separate section for all-day and multi-day events, never mixed into time buckets
- **Sticky header**: title + date picker stay visible while scrolling
- **Yesterday / Tomorrow navigation**: quick date buttons alongside the date input; arrow-only on mobile, full labels on sm+ screens
- **EventCard upgrade**: description (line-clamp-2), category chip pills, source links pinned to card bottom

### Event classification logic

Events whose `start_at` is before the requested date are handled as follows:
- Ends before 3am on the requested date → excluded (night-crossing event belonging to the previous day)
- Otherwise → shown in the all-day strip as an ongoing multi-day event

## Test plan

- [x] Open a busy day (e.g. a Saturday) and confirm density rail bars are visible and proportional
- [x] Click a bar to confirm smooth-scroll to the correct bucket
- [x] Confirm all-day events appear in the All Day strip and not in any time bucket
- [x] Confirm night-crossing events (e.g. a concert ending at 1am) do not appear on the following day
- [x] Check layout at ~375px (mobile), ~768px (tablet), ~1280px (desktop)
- [x] Use Yesterday / Tomorrow buttons to navigate dates
- [x] Confirm sticky header and bucket headers don't overlap awkwardly while scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)