### PR TITLE
Improve Visit Madison time parsing; add all_day flag

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -36,6 +36,7 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
                 venue_address=raw.venue_address,
                 image_url=raw.image_url,
                 categories=list(raw.categories),
+                all_day=raw.all_day,
                 canonical_hash=hash_,
                 status="active",
             )
@@ -56,6 +57,12 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
                     changed = True
             if event.status == "removed":
                 event.status = "active"
+                changed = True
+            # If an all-day placeholder is superseded by a raw with a real time, upgrade it.
+            if event.all_day and not raw.all_day:
+                event.all_day = False
+                event.start_at = raw.start_at
+                event.end_at = raw.end_at
                 changed = True
             if changed:
                 updated += 1

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,6 +18,7 @@ class Event(Base):
     venue_address = Column(String)
     categories = Column(ARRAY(String), default=[])
     image_url = Column(String)
+    all_day = Column(Boolean, nullable=False, server_default="false")
     canonical_hash = Column(String, unique=True, nullable=False)
     status = Column(String, nullable=False, server_default="active")
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,6 +22,7 @@ class EventResponse(BaseModel):
     venue_address: Optional[str] = None
     categories: list[str] = []
     image_url: Optional[str] = None
+    all_day: bool = False
     status: str
     sources: list[SourceRef] = []
 

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -18,6 +18,7 @@ class RawEvent:
     venue_address: Optional[str] = None
     image_url: Optional[str] = None
     categories: list[str] = field(default_factory=list)
+    all_day: bool = False
 
     def canonical_hash(self) -> str:
         key = "|".join([

--- a/backend/app/scrapers/visit_madison.py
+++ b/backend/app/scrapers/visit_madison.py
@@ -16,6 +16,27 @@ _CENTRAL = ZoneInfo("America/Chicago")
 _WINDOW_DAYS = 30
 _PAGE_SIZE = 30
 _PAGE_SLEEP_SECONDS = 0.5
+# Matches "From: 06:00 PM to 08:30 PM" — the structured times format used by
+# one-off events that omit startTime/endTime at the top level.
+_FROM_TO_RE = re.compile(
+    r"From:\s*(\d{1,2}:\d{2}\s*[AP]M)\s*to\s*(\d{1,2}:\d{2}\s*[AP]M)",
+    re.IGNORECASE,
+)
+# Matches "Friday 6:30pm-7:30pm" within a multi-day times string.
+_DAY_TIME_RE = re.compile(
+    r"(monday|tuesday|wednesday|thursday|friday|saturday|sunday|mon|tue|wed|thu|fri|sat|sun)"
+    r"\s+(\d{1,2}(?::\d{2})?(?:am|pm))\s*[-–]\s*(\d{1,2}(?::\d{2})?(?:am|pm))",
+    re.IGNORECASE,
+)
+_WEEKDAY_MAP = {
+    "monday": 0, "mon": 0,
+    "tuesday": 1, "tue": 1,
+    "wednesday": 2, "wed": 2,
+    "thursday": 3, "thu": 3,
+    "friday": 4, "fri": 4,
+    "saturday": 5, "sat": 5,
+    "sunday": 6, "sun": 6,
+}
 
 # Conservative mapping: only Visit Madison categories that map unambiguously to
 # our taxonomy. Unmapped categories are silently dropped — those events remain
@@ -74,9 +95,7 @@ class VisitMadisonSource(BaseSource):
             resp.raise_for_status()
             docs = resp.json().get("docs") or []
             for doc in docs:
-                raw = _to_raw_event(doc)
-                if raw is not None:
-                    events.append(raw)
+                events.extend(_to_raw_events(doc))
             if len(docs) < _PAGE_SIZE:
                 break
             skip += _PAGE_SIZE
@@ -116,6 +135,58 @@ def _parse_iso_z(s: str) -> datetime | None:
         return datetime.fromisoformat(s.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def _parse_from_to_times(times_str: str, event_date: date) -> tuple[datetime, datetime] | None:
+    m = _FROM_TO_RE.search(times_str)
+    if not m:
+        return None
+    try:
+        start_t = datetime.strptime(m.group(1).strip().upper(), "%I:%M %p").time()
+        end_t = datetime.strptime(m.group(2).strip().upper(), "%I:%M %p").time()
+        start_dt = datetime.combine(event_date, start_t, tzinfo=_CENTRAL)
+        end_dt = datetime.combine(event_date, end_t, tzinfo=_CENTRAL)
+        if end_dt < start_dt:
+            end_dt += timedelta(days=1)
+        return start_dt, end_dt
+    except ValueError:
+        return None
+
+
+def _parse_ampm_time(s: str) -> dtime | None:
+    s = s.strip().upper()
+    for fmt in ("%I:%M%p", "%I%p"):
+        try:
+            return datetime.strptime(s, fmt).time()
+        except ValueError:
+            pass
+    return None
+
+
+def _parse_day_occurrences(
+    times_str: str, start_date: date, end_date: date
+) -> list[tuple[date, dtime, dtime]]:
+    """Parse 'Friday 6:30pm-7:30pm, Saturday 11:00am-12:00pm' into per-date occurrences.
+
+    Resolves each day-of-week name to the matching date(s) in [start_date, end_date].
+    Returns an empty list if nothing matches or times can't be parsed.
+    """
+    matches = _DAY_TIME_RE.findall(times_str)
+    if not matches:
+        return []
+    results = []
+    for day_name, start_s, end_s in matches:
+        weekday = _WEEKDAY_MAP.get(day_name.lower())
+        start_t = _parse_ampm_time(start_s)
+        end_t = _parse_ampm_time(end_s)
+        if weekday is None or start_t is None or end_t is None:
+            continue
+        d = start_date
+        while d <= end_date:
+            if d.weekday() == weekday:
+                results.append((d, start_t, end_t))
+            d += timedelta(days=1)
+    return results
 
 
 def _parse_hms(s: str) -> dtime | None:
@@ -166,50 +237,75 @@ def _map_categories(doc: dict) -> list[str]:
     return seen
 
 
-def _to_raw_event(doc: dict) -> RawEvent | None:
+def _to_raw_events(doc: dict) -> list[RawEvent]:
     title = (doc.get("title") or "").strip()
     if not title:
-        return None
+        return []
 
     event_date = _event_local_date(doc)
     if event_date is None:
-        return None
+        return []
 
-    start_time = _parse_hms(doc.get("startTime"))
-    if start_time is not None:
-        start_at = datetime.combine(event_date, start_time, tzinfo=_CENTRAL)
-    else:
-        start_at = datetime.combine(event_date, dtime.min, tzinfo=_CENTRAL)
-
-    end_at: datetime | None = None
-    end_time = _parse_hms(doc.get("endTime"))
-    if end_time is not None:
-        end_at = datetime.combine(event_date, end_time, tzinfo=_CENTRAL)
-        if end_at < start_at:
-            end_at += timedelta(days=1)
+    start_time_hms = _parse_hms(doc.get("startTime"))
+    end_time_hms = _parse_hms(doc.get("endTime"))
+    times_str = (doc.get("times") or "").strip()
 
     venue_name = (doc.get("location") or "").strip() or None
     venue_address = _build_address(doc)
-
     raw_desc = doc.get("description") or doc.get("teaser") or ""
     description = clean_html_text(raw_desc) or None
-
-    image_url = None
-    media = doc.get("media_raw") or []
-    if media:
-        image_url = media[0].get("mediaurl") or None
-
+    image_url = (((doc.get("media_raw") or [{}])[0]).get("mediaurl")) or None
     source_url = doc.get("absoluteUrl") or doc.get("url") or _EVENTS_PAGE_URL
+    categories = _map_categories(doc)
 
-    return RawEvent(
-        title=title,
-        start_at=start_at,
-        end_at=end_at,
-        venue_name=venue_name,
-        venue_address=venue_address,
-        description=description,
-        image_url=image_url,
-        categories=_map_categories(doc),
-        source_name="Visit Madison",
-        source_url=source_url,
-    )
+    def make_event(start_at, end_at=None, all_day=False, desc=description):
+        return RawEvent(
+            title=title,
+            start_at=start_at,
+            end_at=end_at,
+            venue_name=venue_name,
+            venue_address=venue_address,
+            description=desc,
+            image_url=image_url,
+            categories=list(categories),
+            all_day=all_day,
+            source_name="Visit Madison",
+            source_url=source_url,
+        )
+
+    if start_time_hms is not None:
+        start_at = datetime.combine(event_date, start_time_hms, tzinfo=_CENTRAL)
+        end_at = None
+        if end_time_hms is not None:
+            end_at = datetime.combine(event_date, end_time_hms, tzinfo=_CENTRAL)
+            if end_at < start_at:
+                end_at += timedelta(days=1)
+        return [make_event(start_at, end_at)]
+
+    # No top-level startTime — try structured parsing of the times field.
+    parsed = _parse_from_to_times(times_str, event_date) if times_str else None
+    if parsed is not None:
+        return [make_event(*parsed)]
+
+    # Try day-of-week occurrence parsing (e.g. "Friday 6:30pm-7:30pm, Saturday 11:00am-12:00pm").
+    start_date_raw = _parse_iso_z(doc.get("startDate"))
+    end_date_raw = _parse_iso_z(doc.get("endDate"))
+    if start_date_raw and end_date_raw and times_str:
+        start_date_local = start_date_raw.astimezone(_CENTRAL).date()
+        end_date_local = end_date_raw.astimezone(_CENTRAL).date()
+        occurrences = _parse_day_occurrences(times_str, start_date_local, end_date_local)
+        if occurrences:
+            result = []
+            for d, st, et in occurrences:
+                start_at = datetime.combine(d, st, tzinfo=_CENTRAL)
+                end_at = datetime.combine(d, et, tzinfo=_CENTRAL)
+                if end_at < start_at:
+                    end_at += timedelta(days=1)
+                result.append(make_event(start_at, end_at))
+            return result
+
+    # Fall back to all-day with freeform times prepended to description.
+    all_day_desc = description
+    if times_str and "see event description" not in times_str.lower():
+        all_day_desc = f"{times_str} — {description}" if description else times_str
+    return [make_event(datetime.combine(event_date, dtime.min, tzinfo=_CENTRAL), all_day=True, desc=all_day_desc)]

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -4,7 +4,7 @@ export default function AllDayStrip({ events }) {
   return (
     <section id="allday" className="scroll-mt-32 mt-4">
       <h2 className="sticky top-32 z-10 bg-emerald-50 border border-emerald-200 text-emerald-900 rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between">
-        <span>All Day</span>
+        <span>All Day / Time Varies</span>
         <span className="text-xs font-normal opacity-70">
           {events.length} event{events.length === 1 ? '' : 's'}
         </span>
@@ -27,6 +27,9 @@ function AllDayCard({ event }) {
       </h3>
       {event.venue_name && (
         <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
+      )}
+      {event.all_day && event.description && (
+        <p className="text-xs text-gray-400 mt-1 line-clamp-1">{event.description}</p>
       )}
     </>
   )

--- a/frontend/src/lib/eventTime.js
+++ b/frontend/src/lib/eventTime.js
@@ -48,6 +48,7 @@ function isLocalMidnight(iso) {
 }
 
 export function isAllDay(event, requestedDate) {
+  if (event.all_day) return true
   if (!event.start_at) return false
 
   // Multi-day event that fully spans the requested day (started before, ends after).


### PR DESCRIPTION
## Summary

- 14% of Visit Madison events (67/488 in a 30-day window) had no `startTime` and were being stored as midnight, misrepresenting them as all-day events
- Added a three-stage fallback for events missing `startTime`: parse the structured `"From: HH:MM AM/PM to HH:MM AM/PM"` format; parse `"DayName HH:MMpm-HH:MMpm"` patterns to emit one `RawEvent` per occurrence (resolving day names against `startDate`/`endDate`); fall back to `all_day=True` with the freeform times string prepended to the description
- Added `all_day: bool` to `RawEvent`, `Event` model (with `server_default=false`), and API response; ingest upgrades existing all-day placeholders to timed events when a real time comes in on a later run
- Frontend `isAllDay()` now checks the flag directly; all-day cards show the description to surface freeform time info; section retitled "All Day / Time Varies"

## Schema note

The new `all_day` column requires a DB rebuild: `docker compose down -v && docker compose up`, then re-trigger a scrape.

## Test plan

- [x] Trigger a scrape and confirm events previously stored as midnight now have correct times (e.g. Paint & Sip events showing as evening rather than all-day)
- [x] Confirm multi-day shows with day-of-week time strings (e.g. WHOOPENSCKER LIVE!) emit one event per day with the correct time
- [x] Confirm events with no parseable time info appear in "All Day / Time Varies" with their freeform times string visible in the card description

🤖 Generated with [Claude Code](https://claude.com/claude-code)