### PR TITLE
Fix Isthmus scraper missing today's events on late scrapes

### DIFF
--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -20,7 +20,10 @@ class IsthmusSource(BaseSource):
     scraper_type = "ical"
 
     def fetch(self) -> list[RawEvent]:
-        today = date.today()
+        # Use Central time, not the container's clock — backend runs in UTC, so
+        # date.today() returns tomorrow's date after ~7 PM Central, cutting off
+        # today's events from the scrape window.
+        today = datetime.now(_CENTRAL).date()
         end_date = today + timedelta(days=_WINDOW_DAYS)
         url_map, title_date_map = _build_url_map(today, end_date)
         return _parse_ical(today, end_date, url_map, title_date_map)


### PR DESCRIPTION
## Summary
- Isthmus scraper was using `date.today()`, which returns the backend container's date. The container runs in UTC, so any scrape that ran after ~7 PM Central (midnight UTC during DST) computed "today" as tomorrow and dropped today's events from the 30-day window.
- Switch to `datetime.now(_CENTRAL).date()` so the scrape window is anchored to the user-facing timezone, matching the Visit Madison scraper.

## Verified
- Restarted backend, re-ran `POST /admin/scrape`: today's `GET /events?date=2026-05-01` went from 0 Isthmus events → 11.
- `ruff check backend/` clean.

## Test plan
- [x] Restart backend and trigger a scrape; confirm Isthmus events show up for today on the frontend
- [x] `ruff check backend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)