### PR TITLE
Add category filter UI with multi-select tag cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ After writing a scraper, add it to `SCRAPERS` in `backend/app/main.py`. The `POS
 
 ### Category Taxonomy
 
-The closed set of event category tags lives in `backend/app/categories.py` (`CATEGORIES`, `CATEGORY_DESCRIPTIONS`). The same list is mirrored with descriptions in `docs/EVENT_SOURCES.md` under "Category Taxonomy". The LLM tagging pass (Step 4) imports from the module to constrain its output. When changing the taxonomy, update both the module and the doc together — they should always agree.
+The closed set of event category tags lives in `backend/app/categories.py` (`CATEGORIES`, `CATEGORY_DESCRIPTIONS`). The same list is mirrored with descriptions in `docs/EVENT_SOURCES.md` under "Category Taxonomy", and the bare list (plus the default-excluded set used by the frontend filter) is mirrored in `frontend/src/lib/categories.js`. The LLM tagging pass (Step 4) imports from the module to constrain its output. When changing the taxonomy, update the Python module, the doc, and the frontend mirror together — they should always agree.
 
 ### Ingestion (`backend/app/ingest.py`)
 
@@ -151,7 +151,7 @@ Returns per-scraper stats: `{"Isthmus": {"inserted": N, "updated": N, "deactivat
 - **Done (Step 1):** repo skeleton, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class
 - **Done (Step 2):** multi-source `Event`/`EventSource` data model, `ingest.py`, `POST /admin/scrape` endpoint, React/Vite/Tailwind frontend (date picker + event cards)
 - **In progress (Step 3):** Isthmus integrated (iCal + RSS, 30-day window, ~235 events) and Visit Madison integrated (Simpleview JSON API, 30-day window, ~460 events with category pre-tagging); APScheduler for daily runs still planned; more sources in `docs/EVENT_SOURCES.md`
-- **Planned (Step 4):** LLM-assisted category taxonomy pass, category filtering in frontend
+- **In progress (Step 4):** category filter UI in frontend (multi-select tag cloud, default excludes Volunteer & Causes / Civic & Politics / Community & Clubs, persists to localStorage); LLM-assisted category tagging pass still planned (tracked in GH issue #6)
 
 Backend: http://localhost:8000 — API docs: http://localhost:8000/docs
 Frontend: http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ whats-up-madison/
 - **Step 1 — Skeleton** ✅ Repo structure, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class
 - **Step 2 — First scraper + frontend** ✅ Multi-source data model (`Event`/`EventSource`), ingestion utility, React/Vite/Tailwind frontend with date picker and event cards
 - **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); Eventbrite API, City of Madison, individual venue HTML scrapers, APScheduler for daily runs still planned
-- **Step 4 — Categories** LLM analysis of accumulated events to propose a category taxonomy; category filtering added to the frontend
+- **Step 4 — Categories** 🔄 Closed taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source taxonomy; frontend filter UI shipped (multi-select tag cloud, sensible defaults, localStorage); LLM-assisted tagging pass still planned to fill in Isthmus + future sources
 
 ## Adding a Scraper
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,13 @@ import DatePicker from './components/DatePicker'
 import DensityRail from './components/DensityRail'
 import AllDayStrip from './components/AllDayStrip'
 import BucketSection from './components/BucketSection'
+import CategoryFilter from './components/CategoryFilter'
 import { partitionEvents } from './lib/eventTime'
+import {
+  filterEvents,
+  loadFilterState,
+  saveFilterState,
+} from './lib/categories'
 
 function toLocalDateString(date) {
   return date.toLocaleDateString('en-CA') // YYYY-MM-DD in local time
@@ -29,6 +35,7 @@ export default function App() {
   const [events, setEvents] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [filter, setFilter] = useState(loadFilterState)
 
   useEffect(() => {
     setLoading(true)
@@ -43,9 +50,18 @@ export default function App() {
       .finally(() => setLoading(false))
   }, [selectedDate])
 
+  useEffect(() => {
+    saveFilterState(filter)
+  }, [filter])
+
+  const filteredEvents = useMemo(
+    () => filterEvents(events, filter),
+    [events, filter],
+  )
+
   const partition = useMemo(
-    () => partitionEvents(events, selectedDate),
-    [events, selectedDate],
+    () => partitionEvents(filteredEvents, selectedDate),
+    [filteredEvents, selectedDate],
   )
 
   const handleJumpToHour = (hour) => {
@@ -58,7 +74,14 @@ export default function App() {
       <div className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-3">
           <h1 className="text-lg font-bold text-gray-900">What's Up Madison</h1>
-          <DatePicker value={selectedDate} onChange={setSelectedDate} />
+          <div className="flex items-center gap-2">
+            <CategoryFilter
+              selected={filter.selected}
+              includeUncategorized={filter.includeUncategorized}
+              onChange={setFilter}
+            />
+            <DatePicker value={selectedDate} onChange={setSelectedDate} />
+          </div>
         </div>
       </div>
 
@@ -69,10 +92,18 @@ export default function App() {
           {!loading && !error && events.length === 0 && (
             <p className="text-gray-400 text-sm">No events found for this date.</p>
           )}
-          {!loading && !error && events.length > 0 && (
+          {!loading && !error && events.length > 0 && filteredEvents.length === 0 && (
+            <p className="text-gray-400 text-sm">
+              All {events.length} events for this date are hidden by your filter.
+            </p>
+          )}
+          {!loading && !error && filteredEvents.length > 0 && (
             <>
               <p className="text-gray-500 text-xs mb-2">
-                {events.length} event{events.length !== 1 ? 's' : ''}
+                {filteredEvents.length} event{filteredEvents.length !== 1 ? 's' : ''}
+                {filteredEvents.length !== events.length && (
+                  <span className="text-gray-400"> of {events.length}</span>
+                )}
               </p>
               <DensityRail
                 hourCounts={partition.hourCounts}

--- a/frontend/src/components/CategoryFilter.jsx
+++ b/frontend/src/components/CategoryFilter.jsx
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  CATEGORIES,
+  DEFAULT_SELECTED,
+  defaultFilterState,
+  isDefaultFilterState,
+} from '../lib/categories'
+
+export default function CategoryFilter({
+  selected,
+  includeUncategorized,
+  onChange,
+}) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    function handleKey(e) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('mousedown', handleClick)
+    window.addEventListener('keydown', handleKey)
+    return () => {
+      window.removeEventListener('mousedown', handleClick)
+      window.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  function toggleCategory(c) {
+    const next = new Set(selected)
+    if (next.has(c)) next.delete(c)
+    else next.add(c)
+    onChange({ selected: next, includeUncategorized })
+  }
+
+  function setIncludeUncategorized(v) {
+    onChange({ selected, includeUncategorized: v })
+  }
+
+  function selectAll() {
+    onChange({ selected: new Set(CATEGORIES), includeUncategorized: true })
+  }
+
+  function clearAll() {
+    onChange({ selected: new Set(), includeUncategorized: false })
+  }
+
+  function resetDefaults() {
+    onChange(defaultFilterState())
+  }
+
+  const isDefault = isDefaultFilterState({ selected, includeUncategorized })
+  const hiddenCount =
+    CATEGORIES.length - selected.size + (includeUncategorized ? 0 : 1)
+  const showBadge = !isDefault
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`px-2 py-1 text-sm rounded border transition-colors flex items-center gap-1 ${
+          showBadge
+            ? 'border-blue-500 text-blue-700 bg-blue-50 hover:bg-blue-100'
+            : 'border-gray-300 text-gray-700 hover:bg-gray-100'
+        }`}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+      >
+        <span>Filter</span>
+        {showBadge && (
+          <span className="text-[10px] px-1 py-0.5 rounded-full bg-blue-600 text-white leading-none">
+            {hiddenCount} hidden
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Filter by category"
+          className="absolute right-0 mt-2 w-80 sm:w-96 bg-white border border-gray-200 rounded-lg shadow-lg p-3 z-40"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+              Categories
+            </p>
+            <div className="flex gap-2 text-xs">
+              <button
+                type="button"
+                onClick={selectAll}
+                className="text-blue-600 hover:underline"
+              >
+                Select all
+              </button>
+              <span className="text-gray-300">·</span>
+              <button
+                type="button"
+                onClick={clearAll}
+                className="text-blue-600 hover:underline"
+              >
+                Clear
+              </button>
+              <span className="text-gray-300">·</span>
+              <button
+                type="button"
+                onClick={resetDefaults}
+                className="text-blue-600 hover:underline"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 mb-3">
+            {CATEGORIES.map((c) => {
+              const active = selected.has(c)
+              const isDefaultExcluded = !DEFAULT_SELECTED.has(c)
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => toggleCategory(c)}
+                  className={`text-xs px-2 py-1 rounded-full border transition-colors ${
+                    active
+                      ? 'bg-blue-600 border-blue-600 text-white hover:bg-blue-700'
+                      : `bg-white text-gray-600 hover:bg-gray-50 ${
+                          isDefaultExcluded
+                            ? 'border-dashed border-gray-300'
+                            : 'border-gray-300'
+                        }`
+                  }`}
+                  aria-pressed={active}
+                  title={
+                    isDefaultExcluded && !active
+                      ? 'Hidden by default'
+                      : undefined
+                  }
+                >
+                  {c}
+                </button>
+              )
+            })}
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-gray-700 pt-2 border-t border-gray-100">
+            <input
+              type="checkbox"
+              checked={includeUncategorized}
+              onChange={(e) => setIncludeUncategorized(e.target.checked)}
+              className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span>Show uncategorized events</span>
+          </label>
+          <p className="text-[11px] text-gray-400 mt-1 pl-6">
+            Many events aren't tagged yet. Hide them once tagging is more
+            complete.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/categories.js
+++ b/frontend/src/lib/categories.js
@@ -1,0 +1,86 @@
+// Mirror of `backend/app/categories.py`. Keep the two in sync when the
+// taxonomy changes.
+
+export const CATEGORIES = [
+  'Music',
+  'Open Mic & Comedy',
+  'Theater & Stage',
+  'Visual Art',
+  'Dance',
+  'Trivia & Games',
+  'Food & Drink',
+  'Health & Wellness',
+  'Outdoors & Nature',
+  'Sports & Recreation',
+  'Talks & Learning',
+  'Civic & Politics',
+  'Family & Kids',
+  'Community & Clubs',
+  'Volunteer & Causes',
+]
+
+export const DEFAULT_EXCLUDED = new Set([
+  'Volunteer & Causes',
+  'Civic & Politics',
+  'Community & Clubs',
+])
+
+export const DEFAULT_SELECTED = new Set(
+  CATEGORIES.filter((c) => !DEFAULT_EXCLUDED.has(c)),
+)
+
+const STORAGE_KEY = 'wum.categoryFilter.v1'
+
+export function loadFilterState() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return defaultFilterState()
+    const parsed = JSON.parse(raw)
+    const selected = new Set(
+      (parsed.selected || []).filter((c) => CATEGORIES.includes(c)),
+    )
+    const includeUncategorized = parsed.includeUncategorized !== false
+    return { selected, includeUncategorized }
+  } catch {
+    return defaultFilterState()
+  }
+}
+
+export function saveFilterState({ selected, includeUncategorized }) {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        selected: [...selected],
+        includeUncategorized,
+      }),
+    )
+  } catch {
+    // Ignore storage errors (private mode, quota, etc.)
+  }
+}
+
+export function defaultFilterState() {
+  return {
+    selected: new Set(DEFAULT_SELECTED),
+    includeUncategorized: true,
+  }
+}
+
+export function isDefaultFilterState({ selected, includeUncategorized }) {
+  if (!includeUncategorized) return false
+  if (selected.size !== DEFAULT_SELECTED.size) return false
+  for (const c of DEFAULT_SELECTED) {
+    if (!selected.has(c)) return false
+  }
+  return true
+}
+
+export function filterEvents(events, { selected, includeUncategorized }) {
+  return events.filter((e) => {
+    if (!e.categories || e.categories.length === 0) {
+      return includeUncategorized
+    }
+    return e.categories.some((c) => selected.has(c))
+  })
+}


### PR DESCRIPTION
## Summary
- Filter button in the sticky header opens a tag-cloud popover. Multi-select chips with OR semantics — an event passes if any of its categories is selected.
- Default state hides `Volunteer & Causes`, `Civic & Politics`, and `Community & Clubs` to focus the at-a-glance view on "things to do". Default-excluded chips show as dashed outlines when off.
- Separate "Show uncategorized events" toggle (defaults on) keeps Isthmus events visible until the LLM tagging pass in #6 lands.
- Filter state persists to `localStorage` (`wum.categoryFilter.v1`).
- Filtering is client-side over the existing `GET /events?date=` payload — daily event counts are bounded enough that no API change is warranted.
- Frontend mirror of the taxonomy lives in `frontend/src/lib/categories.js`; `AGENTS.md` notes the three places (Python module, source-catalog doc, frontend mirror) that need to stay in sync.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` introduces no new errors (one pre-existing `react-hooks/set-state-in-effect` on `App.jsx` exists on main)
- [x] Manual browser check: popover opens/closes (click-outside + Escape), chips toggle, "Select all" / "Clear" / "Reset" work, uncategorized toggle hides Isthmus events when off, badge shows hidden count when filter differs from default, persistence survives reload
- [x] Verified against real data on 2026-05-01: 65 events, default filter hides ~24 (Volunteer/Community), uncategorized toggle controls 11 Isthmus events

## Related
- #6 — LLM tagging pass that will fill in categories for Isthmus + future sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)