### PR TITLE
Add LLM-assisted category tagging (issue #6)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgresql://whatsup:whatsup@localhost:5432/whatsup
 ENVIRONMENT=development
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+ANTHROPIC_API_KEY=your-key-here
+TAGGER_MODEL=claude-haiku-4-5

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,6 +5,8 @@ class Settings(BaseSettings):
     database_url: str = "postgresql://whatsup:whatsup@localhost:5432/whatsup"
     environment: str = "development"
     cors_origins: str = "http://localhost:5173,http://localhost:3000"
+    anthropic_api_key: str = ""
+    tagger_model: str = "claude-haiku-4-5"
 
     def get_cors_origins(self) -> list[str]:
         return [o.strip() for o in self.cors_origins.split(",")]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.ingest import ingest_events
 from app.routers import events
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.visit_madison import VisitMadisonSource
+from app.tagger import tag_untagged_events
 
 Base.metadata.create_all(bind=engine)
 
@@ -40,4 +41,16 @@ def trigger_scrape(db: Session = Depends(get_db)):
             results[scraper.name] = stats
         except Exception as e:
             results[scraper.name] = {"error": str(e)}
+    try:
+        results["_tagging"] = tag_untagged_events(db)
+    except Exception as e:
+        results["_tagging"] = {"error": str(e)}
     return results
+
+
+@app.post("/admin/tag")
+def trigger_tag(model: str = None, db: Session = Depends(get_db)):
+    try:
+        return tag_untagged_events(db, model=model)
+    except Exception as e:
+        return {"error": str(e)}

--- a/backend/app/tagger.py
+++ b/backend/app/tagger.py
@@ -1,0 +1,156 @@
+import json
+import logging
+from typing import Optional
+
+import anthropic
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.categories import CATEGORIES, CATEGORY_DESCRIPTIONS
+from app.config import settings
+from app.models import Event
+
+logger = logging.getLogger(__name__)
+
+_CATEGORIES_SET = frozenset(CATEGORIES)
+_MIN_DESCRIPTION_LEN = 80
+
+_SYSTEM_PROMPT = (
+    "You are a category classifier for a Madison, WI community events listing.\n\n"
+    "For each event in the batch, assign zero or more categories from the taxonomy below. "
+    "Use only these exact category names. Assign multiple only when the event genuinely fits "
+    "more than one. Leave the list empty if no category fits well.\n\n"
+    "CATEGORY TAXONOMY:\n"
+    + "\n".join(f"- {name}: {desc}" for name, desc in CATEGORY_DESCRIPTIONS.items())
+    + "\n\n"
+    "Respond with one line per event: ID:Category1,Category2 "
+    "(comma-separated, no spaces around commas). "
+    "Use an empty value after the colon if no category fits. "
+    "Output only these lines — no explanation, no markdown.\n\n"
+    "Example:\n"
+    "0:Music\n"
+    "1:Food & Drink,Community & Clubs\n"
+    "2:"
+)
+
+
+def _build_event_payload(event: Event) -> Optional[dict]:
+    """Returns None if the event lacks sufficient context for tagging."""
+    desc = event.description
+    if not desc or len(desc.strip()) < _MIN_DESCRIPTION_LEN:
+        return None
+    payload: dict = {"title": event.title, "description": desc.strip()}
+    if event.venue_name:
+        payload["venue"] = event.venue_name
+    return payload
+
+
+def _call_llm(
+    client: anthropic.Anthropic, model: str, batch: list[dict]
+) -> tuple[dict, dict]:
+    """
+    Tag a batch of events via the LLM.
+
+    batch: list of dicts with keys id (str), title, description, venue (optional)
+    Returns: (predictions mapping str(id) -> list[str] categories, usage dict)
+    """
+    user_msg = "\n".join(json.dumps(item) for item in batch)
+
+    response = client.messages.create(
+        model=model,
+        max_tokens=2048,
+        system=[
+            {
+                "type": "text",
+                "text": _SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    usage = {
+        "input_tokens": response.usage.input_tokens,
+        "cache_creation_input_tokens": getattr(
+            response.usage, "cache_creation_input_tokens", 0
+        ),
+        "cache_read_input_tokens": getattr(
+            response.usage, "cache_read_input_tokens", 0
+        ),
+        "output_tokens": response.usage.output_tokens,
+    }
+
+    predictions: dict = {}
+    for line in response.content[0].text.strip().splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        idx, _, cats_str = line.partition(":")
+        idx = idx.strip()
+        cats = [c.strip() for c in cats_str.split(",") if c.strip() in _CATEGORIES_SET]
+        predictions[idx] = cats
+
+    return predictions, usage
+
+
+def tag_untagged_events(db: Session, model: Optional[str] = None) -> dict:
+    """Tag active events that have no categories and a sufficient description."""
+    model = model or settings.tagger_model
+
+    if not settings.anthropic_api_key:
+        raise ValueError("ANTHROPIC_API_KEY is not configured")
+
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+
+    candidates = (
+        db.query(Event)
+        .filter(
+            Event.status == "active",
+            func.coalesce(func.cardinality(Event.categories), 0) == 0,
+        )
+        .all()
+    )
+
+    to_tag: list[tuple[Event, dict]] = []
+    skipped_no_desc = 0
+    for event in candidates:
+        payload = _build_event_payload(event)
+        if payload is None:
+            skipped_no_desc += 1
+        else:
+            to_tag.append((event, payload))
+
+    tagged = 0
+    batches = 0
+    batch_size = 25
+
+    for i in range(0, len(to_tag), batch_size):
+        batch_items = to_tag[i : i + batch_size]
+        batch_payload = [
+            {"id": str(j), **payload} for j, (_, payload) in enumerate(batch_items)
+        ]
+
+        try:
+            predictions, _ = _call_llm(client, model, batch_payload)
+        except Exception as e:
+            logger.warning(
+                "Tagger: LLM call failed for batch starting at index %d: %s", i, e
+            )
+            batches += 1
+            continue
+
+        for j, (event, _) in enumerate(batch_items):
+            cats = predictions.get(str(j), [])
+            if cats:
+                event.categories = cats
+                tagged += 1
+
+        db.commit()
+        batches += 1
+
+    return {
+        "tagged": tagged,
+        "skipped_no_description": skipped_no_desc,
+        "candidates": len(candidates),
+        "batches": batches,
+    }

--- a/backend/eval_tagger.py
+++ b/backend/eval_tagger.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Cost experimentation eval for the LLM category tagger.
+
+Run from backend/ with the project conda env:
+    ~/miniconda3/envs/whats-up-madison/bin/python eval_tagger.py [options]
+
+Options:
+    --models haiku sonnet     Models to compare (default: haiku sonnet)
+    --sample 50               Events to evaluate (default: 50)
+    --batch-sizes 1 5 10 25   Batch sizes to test (default: 25)
+    --formats json compact    Output formats to test (default: json)
+
+Uses Visit Madison events (pre-tagged by the scraper) as ground truth.
+Strips categories in memory and asks each model to re-predict them, then scores results.
+No writes to the database.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / ".env")
+
+import anthropic  # noqa: E402
+from sqlalchemy import create_engine, func  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.categories import CATEGORIES, CATEGORY_DESCRIPTIONS  # noqa: E402
+from app.config import settings  # noqa: E402
+from app.models import Event  # noqa: E402
+from app.tagger import _build_event_payload  # noqa: E402
+
+MODEL_IDS = {
+    "haiku": "claude-haiku-4-5",
+    "sonnet": "claude-sonnet-4-6",
+}
+
+# Published prices per million tokens: (input $/MTok, output $/MTok)
+MODEL_PRICES = {
+    "claude-haiku-4-5": (1.00, 5.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+}
+
+_CATEGORIES_SET = frozenset(CATEGORIES)
+_TAXONOMY_TEXT = "\n".join(f"- {name}: {desc}" for name, desc in CATEGORY_DESCRIPTIONS.items())
+
+# --- Format: json ---
+# Output: {"0": ["Music"], "1": ["Food & Drink"], "2": []}
+_SYSTEM_PROMPT_JSON = (
+    "You are a category classifier for a Madison, WI community events listing.\n\n"
+    "For each event in the batch, assign zero or more categories from the taxonomy below. "
+    "Use only these exact category names. Assign multiple only when the event genuinely fits "
+    "more than one. Return an empty list if no category fits well.\n\n"
+    "CATEGORY TAXONOMY:\n"
+    + _TAXONOMY_TEXT
+    + "\n\n"
+    "Respond with a single JSON object mapping each event's string id to a list of category "
+    "names. Output only the JSON object — no explanation, no markdown fences.\n\n"
+    'Example: {"0": ["Music"], "1": ["Food & Drink", "Community & Clubs"], "2": []}'
+)
+
+# --- Format: compact ---
+# Output: one line per event — ID:Category1,Category2 (empty after colon = no categories)
+_SYSTEM_PROMPT_COMPACT = (
+    "You are a category classifier for a Madison, WI community events listing.\n\n"
+    "For each event in the batch, assign zero or more categories from the taxonomy below. "
+    "Use only these exact category names. Assign multiple only when the event genuinely fits "
+    "more than one. Leave the list empty if no category fits well.\n\n"
+    "CATEGORY TAXONOMY:\n"
+    + _TAXONOMY_TEXT
+    + "\n\n"
+    "Respond with one line per event: ID:Category1,Category2 "
+    "(comma-separated, no spaces around commas). "
+    "Use an empty value after the colon if no category fits. "
+    "Output only these lines — no explanation, no markdown.\n\n"
+    "Example:\n"
+    "0:Music\n"
+    "1:Food & Drink,Community & Clubs\n"
+    "2:"
+)
+
+FORMATS = {
+    "json": _SYSTEM_PROMPT_JSON,
+    "compact": _SYSTEM_PROMPT_COMPACT,
+}
+
+
+def _parse_json_response(raw_text: str) -> dict:
+    try:
+        parsed = json.loads(raw_text)
+    except json.JSONDecodeError:
+        return {}
+    predictions = {}
+    for key, cats in parsed.items():
+        if isinstance(cats, list):
+            predictions[str(key)] = [c for c in cats if c in _CATEGORIES_SET]
+    return predictions
+
+
+def _parse_compact_response(raw_text: str) -> dict:
+    predictions = {}
+    for line in raw_text.splitlines():
+        line = line.strip()
+        if not line or ":" not in line:
+            continue
+        idx, _, cats_str = line.partition(":")
+        idx = idx.strip()
+        cats = [c.strip() for c in cats_str.split(",") if c.strip() in _CATEGORIES_SET]
+        predictions[idx] = cats
+    return predictions
+
+
+PARSERS = {
+    "json": _parse_json_response,
+    "compact": _parse_compact_response,
+}
+
+
+def _call_llm_eval(
+    client: anthropic.Anthropic,
+    model: str,
+    batch: list[dict],
+    fmt: str,
+) -> tuple[dict, dict]:
+    user_msg = "\n".join(json.dumps(item) for item in batch)
+
+    response = client.messages.create(
+        model=model,
+        max_tokens=4096,
+        system=[
+            {
+                "type": "text",
+                "text": FORMATS[fmt],
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        messages=[{"role": "user", "content": user_msg}],
+    )
+
+    usage = {
+        "input_tokens": response.usage.input_tokens,
+        "cache_creation_input_tokens": getattr(response.usage, "cache_creation_input_tokens", 0),
+        "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0),
+        "output_tokens": response.usage.output_tokens,
+    }
+
+    raw_text = response.content[0].text.strip()
+    predictions = PARSERS[fmt](raw_text)
+    return predictions, usage
+
+
+def compute_metrics(
+    predicted: list[str], ground_truth: list[str]
+) -> tuple[float, float, float]:
+    pred_set = set(predicted)
+    truth_set = set(ground_truth)
+    if not truth_set and not pred_set:
+        return 1.0, 1.0, 1.0
+    if not truth_set:
+        return 0.0, 1.0, 0.0
+    if not pred_set:
+        return 1.0, 0.0, 0.0
+    tp = len(pred_set & truth_set)
+    precision = tp / len(pred_set)
+    recall = tp / len(truth_set)
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1
+
+
+def estimate_cost(usage: dict, model_id: str) -> float:
+    input_price, output_price = MODEL_PRICES.get(model_id, (0.0, 0.0))
+    regular = usage["input_tokens"]
+    cache_write = usage.get("cache_creation_input_tokens", 0)
+    cache_read = usage.get("cache_read_input_tokens", 0)
+    return (
+        regular / 1e6 * input_price
+        + cache_write / 1e6 * input_price * 1.25
+        + cache_read / 1e6 * input_price * 0.1
+        + usage["output_tokens"] / 1e6 * output_price
+    )
+
+
+def run_combination(
+    client: anthropic.Anthropic,
+    model_id: str,
+    eval_events: list[tuple],
+    batch_size: int,
+    fmt: str,
+) -> dict:
+    all_predictions: dict[str, list[str]] = {}
+    total_usage: dict[str, int] = {
+        "input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "output_tokens": 0,
+    }
+    failed_batches = 0
+
+    for i in range(0, len(eval_events), batch_size):
+        chunk = eval_events[i : i + batch_size]
+        batch_payload = [
+            {"id": str(j), **payload} for j, (_, payload, _) in enumerate(chunk)
+        ]
+        try:
+            predictions, usage = _call_llm_eval(client, model_id, batch_payload, fmt)
+        except Exception as e:
+            print(f"    ERROR in batch starting at {i}: {e}")
+            failed_batches += 1
+            continue
+
+        for j in range(len(chunk)):
+            all_predictions[str(i + j)] = predictions.get(str(j), [])
+        for key in total_usage:
+            total_usage[key] += usage.get(key, 0)
+
+    precisions, recalls, f1s, cat_counts = [], [], [], []
+    for i, (_, _, ground_truth) in enumerate(eval_events):
+        predicted = all_predictions.get(str(i), [])
+        p, r, f = compute_metrics(predicted, ground_truth)
+        precisions.append(p)
+        recalls.append(r)
+        f1s.append(f)
+        cat_counts.append(len(predicted))
+
+    total_cost = estimate_cost(total_usage, model_id)
+    cost_per_1k = total_cost / len(eval_events) * 1000
+
+    return {
+        "avg_cats": sum(cat_counts) / len(cat_counts),
+        "precision": sum(precisions) / len(precisions),
+        "recall": sum(recalls) / len(recalls),
+        "f1": sum(f1s) / len(f1s),
+        "est_cost_per_1k": cost_per_1k,
+        "failed_batches": failed_batches,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Cost experimentation eval for LLM category tagging"
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        choices=list(MODEL_IDS),
+        default=["haiku", "sonnet"],
+        help="Models to evaluate (default: haiku sonnet)",
+    )
+    parser.add_argument(
+        "--sample",
+        type=int,
+        default=50,
+        help="Number of events to evaluate (default: 50)",
+    )
+    parser.add_argument(
+        "--batch-sizes",
+        nargs="+",
+        type=int,
+        default=[25],
+        metavar="N",
+        help="Batch sizes to test (default: 25)",
+    )
+    parser.add_argument(
+        "--formats",
+        nargs="+",
+        choices=list(FORMATS),
+        default=["json"],
+        help="Output formats to test (default: json)",
+    )
+    args = parser.parse_args()
+
+    if not settings.anthropic_api_key:
+        print("Error: ANTHROPIC_API_KEY is not set in .env")
+        sys.exit(1)
+
+    engine = create_engine(settings.database_url)
+    with Session(engine) as db:
+        raw_events = (
+            db.query(Event)
+            .filter(
+                Event.status == "active",
+                func.cardinality(Event.categories) > 0,
+            )
+            .limit(args.sample * 4)
+            .all()
+        )
+
+    eval_events: list[tuple] = []
+    for ev in raw_events:
+        payload = _build_event_payload(ev)
+        if payload is not None:
+            eval_events.append((ev, payload, list(ev.categories)))
+        if len(eval_events) >= args.sample:
+            break
+
+    if not eval_events:
+        print(
+            "No suitable events found.\n"
+            "Need active events with non-empty categories and description >= 80 chars.\n"
+            "Run a scrape first: curl -X POST http://localhost:8000/admin/scrape"
+        )
+        sys.exit(1)
+
+    n_combos = len(args.models) * len(args.batch_sizes) * len(args.formats)
+    print(
+        f"Evaluating {len(eval_events)} events: "
+        f"{len(args.models)} model(s) × {len(args.batch_sizes)} batch size(s) × "
+        f"{len(args.formats)} format(s) = {n_combos} combination(s)...\n"
+    )
+
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    results = []
+
+    for short_name in args.models:
+        model_id = MODEL_IDS[short_name]
+        for fmt in args.formats:
+            for batch_size in args.batch_sizes:
+                label = f"{short_name}/{fmt}/batch={batch_size}"
+                print(f"  {label}...", flush=True)
+                metrics = run_combination(client, model_id, eval_events, batch_size, fmt)
+                if metrics["failed_batches"]:
+                    print(f"    ({metrics['failed_batches']} failed batch(es))")
+                results.append(
+                    {
+                        "model": short_name,
+                        "fmt": fmt,
+                        "batch_size": batch_size,
+                        **metrics,
+                    }
+                )
+
+    if not results:
+        print("No results to display.")
+        sys.exit(1)
+
+    print()
+    header = (
+        f"{'Model':<8} {'Format':<8} {'Batch':>6} "
+        f"{'Precision':>9} {'Recall':>6} {'F1':>5} {'$/1k events':>11}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        print(
+            f"{r['model']:<8} {r['fmt']:<8} {r['batch_size']:>6} "
+            f"{r['precision']:>9.3f} {r['recall']:>6.3f} "
+            f"{r['f1']:>5.3f} {r['est_cost_per_1k']:>11.4f}"
+        )
+
+    print("\nTo use a model in production, set TAGGER_MODEL in backend/.env:")
+    for short, full in MODEL_IDS.items():
+        print(f"  {short} → TAGGER_MODEL={full}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ recurring_ical_events>=3.0
 beautifulsoup4>=4.12
 lxml>=5.3
 apscheduler>=3.10
+anthropic>=0.40

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -31,6 +31,18 @@ function AllDayCard({ event }) {
       {event.all_day && event.description && (
         <p className="text-xs text-gray-400 mt-1 line-clamp-1">{event.description}</p>
       )}
+      {event.categories?.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap gap-1">
+          {event.categories.map((c) => (
+            <span
+              key={c}
+              className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+            >
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
     </>
   )
   if (primary?.source_url) {


### PR DESCRIPTION
## Summary

- Adds a post-scrape LLM pass that tags active events with no categories using `claude-haiku-4-5`
- Skips events already tagged by a scraper, and events with missing/short descriptions (<80 chars) — those are treated as a scraper signal, not an LLM problem
- Uses a compact line-based output format (`ID:Cat1,Cat2`) discovered via eval to be more reliable than JSON for haiku at multi-event batch sizes
- Wires tagging into `POST /admin/scrape` automatically; also exposes `POST /admin/tag` for standalone runs
- Adds `eval_tagger.py` for model/format/batch-size cost experimentation
- Fixes all-day event cards missing category pill display (filter was already correct)

## Performance (from eval on 50 Visit Madison events)

| Model | Format | Batch | F1 | $/1k events |
|-------|--------|-------|----|-------------|
| haiku | compact | 25 | 0.650 | $0.28 |
| sonnet | json | 10 | 0.683 | $1.02 |

haiku+compact at batch=25 chosen for production: 3-4x cheaper with only ~5% F1 difference.

## Test plan

- [ ] `docker compose up --build` to install `anthropic` package in container
- [ ] `curl -X POST http://localhost:8000/admin/scrape` — response includes `"_tagging": {"tagged": N, ...}`
- [ ] Spot-check a tagged event has categories visible in the frontend
- [ ] Confirm all-day events show category pills
- [ ] Confirm category filter hides/shows all-day events correctly
- [ ] `ANTHROPIC_API_KEY` must be set in `backend/.env`

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)