### PR TITLE
Click-to-expand event cards; fix paragraph breaks in descriptions

### DIFF
--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -30,11 +30,17 @@ class RawEvent:
 
 
 def clean_html_text(s: str) -> str:
-    """Unescape HTML entities and strip tags; collapses whitespace to a single line."""
+    """Unescape HTML entities, strip tags, and preserve paragraph structure."""
     s = html.unescape(s)
+    # Block-level closers become paragraph breaks; <br> becomes a line break
+    s = re.sub(r"<br\s*/?>", "\n", s, flags=re.IGNORECASE)
+    s = re.sub(r"</(p|div|h[1-6]|li|section|article)>", "\n\n", s, flags=re.IGNORECASE)
     s = re.sub(r"<[^>]+>", "", s)
-    s = re.sub(r"\s+", " ", s).strip()
-    return s
+    # Collapse horizontal whitespace (but not newlines)
+    s = re.sub(r"[^\S\n]+", " ", s)
+    # At most one blank line between paragraphs
+    s = re.sub(r"\n{3,}", "\n\n", s)
+    return s.strip()
 
 
 class BaseSource:

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 export default function AllDayStrip({ events }) {
   if (!events || events.length === 0) return null
 
@@ -19,17 +21,36 @@ export default function AllDayStrip({ events }) {
 }
 
 function AllDayCard({ event }) {
+  const [expanded, setExpanded] = useState(false)
   const primary = event.sources?.[0]
-  const Inner = (
-    <>
-      <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2">
-        {event.title}
-      </h3>
+
+  return (
+    <div
+      className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none"
+      onClick={() => setExpanded(e => !e)}
+    >
+      {primary?.source_url ? (
+        <a
+          href={primary.source_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm font-semibold text-gray-900 leading-snug hover:underline line-clamp-2 block"
+          onClick={e => e.stopPropagation()}
+        >
+          {event.title}
+        </a>
+      ) : (
+        <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2">
+          {event.title}
+        </h3>
+      )}
       {event.venue_name && (
         <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
       )}
-      {event.all_day && event.description && (
-        <p className="text-xs text-gray-400 mt-1 line-clamp-1">{event.description}</p>
+      {event.description && (
+        <p className={`text-xs text-gray-400 mt-1 whitespace-pre-line ${expanded ? '' : 'line-clamp-1'}`}>
+          {event.description}
+        </p>
       )}
       {event.categories?.length > 0 && (
         <div className="mt-1.5 flex flex-wrap gap-1">
@@ -43,23 +64,9 @@ function AllDayCard({ event }) {
           ))}
         </div>
       )}
-    </>
-  )
-  if (primary?.source_url) {
-    return (
-      <a
-        href={primary.source_url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm hover:border-emerald-300 hover:shadow transition"
-      >
-        {Inner}
-      </a>
-    )
-  }
-  return (
-    <div className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm">
-      {Inner}
+      <div className="mt-1 flex justify-end">
+        <span className="text-[10px] text-gray-300">{expanded ? '▲' : '▼'}</span>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -22,7 +22,7 @@ export default function BucketSection({ id, label, events }) {
           {events.length} event{events.length === 1 ? '' : 's'}
         </span>
       </h2>
-      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
         {events.map((event) => (
           <EventCard key={event.id} event={event} />
         ))}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,15 +1,44 @@
+import { useState } from 'react'
 import { formatTimeRange } from '../lib/eventTime'
 
 export default function EventCard({ event }) {
+  const [expanded, setExpanded] = useState(false)
+  const primaryUrl = event.sources?.[0]?.source_url
+
   return (
-    <div className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col h-full">
+    <div
+      className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none"
+      onClick={() => setExpanded(e => !e)}
+    >
       <p className="text-xs text-gray-400 mb-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
-      <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
+      {primaryUrl ? (
+        <a
+          href={primaryUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-base font-semibold text-gray-900 leading-snug hover:underline"
+          onClick={e => e.stopPropagation()}
+        >
+          {event.title}
+        </a>
+      ) : (
+        <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
+      )}
       {event.venue_name && (
         <p className="text-sm text-gray-500 mt-0.5">{event.venue_name}</p>
       )}
       {event.description && (
-        <p className="text-sm text-gray-600 mt-2 line-clamp-2">{event.description}</p>
+        expanded ? (
+          <div className="mt-2 space-y-2">
+            {event.description.split('\n\n').map((para, i) => (
+              <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-600 mt-2 line-clamp-2 whitespace-pre-line">
+            {event.description}
+          </p>
+        )
       )}
       {event.categories?.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1">
@@ -32,12 +61,16 @@ export default function EventCard({ event }) {
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs text-blue-600 hover:underline"
+              onClick={e => e.stopPropagation()}
             >
               {s.source_name} ↗
             </a>
           ))}
         </div>
       )}
+      <div className="mt-auto pt-1 flex justify-end">
+        <span className="text-[10px] text-gray-300">{expanded ? '▲' : '▼'}</span>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #9.

## Summary

- **EventCard**: clicking anywhere on a card expands it to show the full description and source links; the title is a direct `<a>` link to the primary source URL (clicking it navigates without toggling the card)
- **AllDayCard**: same expand/collapse pattern, replacing the previous whole-card-as-`<a>` approach
- **BucketSection grid**: added `items-start` so expanding one card does not stretch its row siblings to match height
- **`clean_html_text`**: now preserves paragraph structure — block-level HTML elements (`<p>`, `<br>`, `<div>`, `<li>`, etc.) are converted to newlines before tags are stripped, rather than collapsing all whitespace to a single space; expanded cards render paragraphs with `space-y-2` for clean visual separation

A DB wipe + re-scrape is needed to get the improved descriptions for existing events (`docker compose down -v && docker compose up`, then `POST /admin/scrape`).

## Test plan

- [ ] Collapsed card shows time, title (underlined link), venue, 2-line description, category tags, source link(s), and ▼ chevron
- [ ] Clicking the card body expands to full description with paragraph breaks and ▲ chevron
- [ ] Clicking the title navigates to source in new tab; card does not toggle
- [ ] Expanding one card does not resize its row neighbors
- [ ] AllDayStrip cards expand/collapse the same way; title is a link
- [ ] After re-scrape, Visit Madison descriptions show paragraph breaks instead of wall-of-text

🤖 Generated with [Claude Code](https://claude.com/claude-code)