### PR TITLE
Add to calendar and share actions on event cards (closes #14)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^1.14.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -2302,6 +2303,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/merge2": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,4 +1,6 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
+import { CalendarDays, Send, Check } from 'lucide-react'
+import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 
 export default function AllDayStrip({ events }) {
   if (!events || events.length === 0) return null
@@ -22,28 +24,122 @@ export default function AllDayStrip({ events }) {
 
 function AllDayCard({ event }) {
   const [expanded, setExpanded] = useState(false)
+  const [calOpen, setCalOpen] = useState(false)
+  const [sendOpen, setSendOpen] = useState(false)
+  const [showCheck, setShowCheck] = useState(false)
+  const calRef = useRef(null)
+  const sendRef = useRef(null)
   const primary = event.sources?.[0]
+
+  useEffect(() => {
+    if (!calOpen) return
+    function handleOutside(e) {
+      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [calOpen])
+
+  useEffect(() => {
+    if (!sendOpen) return
+    function handleOutside(e) {
+      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [sendOpen])
+
+  function flashCheck() {
+    setShowCheck(true)
+    setTimeout(() => setShowCheck(false), 1500)
+  }
+
+  async function handleCopyText(e) {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(formatEventText(event))
+    setSendOpen(false)
+    flashCheck()
+  }
+
+  async function handleSendInvite(e) {
+    e.stopPropagation()
+    const result = await shareCalendarInvite(event)
+    setSendOpen(false)
+    if (result?.downloaded) flashCheck()
+  }
 
   return (
     <div
       className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none"
       onClick={() => setExpanded(e => !e)}
     >
-      {primary?.source_url ? (
-        <a
-          href={primary.source_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm font-semibold text-gray-900 leading-snug hover:underline line-clamp-2 block"
-          onClick={e => e.stopPropagation()}
-        >
-          {event.title}
-        </a>
-      ) : (
-        <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2">
-          {event.title}
-        </h3>
-      )}
+      <div className="flex items-start justify-between gap-1">
+        {primary?.source_url ? (
+          <a
+            href={primary.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-gray-900 leading-snug hover:underline line-clamp-2 block flex-1 min-w-0"
+            onClick={e => e.stopPropagation()}
+          >
+            {event.title}
+          </a>
+        ) : (
+          <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 flex-1 min-w-0">{event.title}</h3>
+        )}
+        <div className="flex items-center gap-0.5 flex-shrink-0 ml-1">
+          <div className="relative" ref={calRef}>
+            <button
+              className="text-gray-400 hover:text-gray-600 p-0.5 rounded cursor-pointer"
+              onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+              title="Add to calendar"
+            >
+              <CalendarDays size={13} />
+            </button>
+            {calOpen && (
+              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                >
+                  Google Calendar
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                >
+                  Apple / Outlook (.ics)
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="relative" ref={sendRef}>
+            <button
+              className={`p-0.5 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+              onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+              title="Send / share event"
+            >
+              {showCheck ? <Check size={13} /> : <Send size={13} />}
+            </button>
+            {sendOpen && (
+              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={handleCopyText}
+                >
+                  Copy text
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={handleSendInvite}
+                >
+                  Calendar invite
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
       {event.venue_name && (
         <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
       )}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,16 +1,114 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
+import { CalendarDays, Send, Check } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
+import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 
 export default function EventCard({ event }) {
   const [expanded, setExpanded] = useState(false)
+  const [calOpen, setCalOpen] = useState(false)
+  const [sendOpen, setSendOpen] = useState(false)
+  const [showCheck, setShowCheck] = useState(false)
+  const calRef = useRef(null)
+  const sendRef = useRef(null)
   const primaryUrl = event.sources?.[0]?.source_url
+
+  useEffect(() => {
+    if (!calOpen) return
+    function handleOutside(e) {
+      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [calOpen])
+
+  useEffect(() => {
+    if (!sendOpen) return
+    function handleOutside(e) {
+      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [sendOpen])
+
+  function flashCheck() {
+    setShowCheck(true)
+    setTimeout(() => setShowCheck(false), 1500)
+  }
+
+  async function handleCopyText(e) {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(formatEventText(event))
+    setSendOpen(false)
+    flashCheck()
+  }
+
+  async function handleSendInvite(e) {
+    e.stopPropagation()
+    const result = await shareCalendarInvite(event)
+    setSendOpen(false)
+    if (result?.downloaded) flashCheck()
+  }
 
   return (
     <div
       className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none"
       onClick={() => setExpanded(e => !e)}
     >
-      <p className="text-xs text-gray-400 mb-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+      <div className="flex items-start justify-between mb-0.5">
+        <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
+        <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
+          <div className="relative" ref={calRef}>
+            <button
+              className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+              onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+              title="Add to calendar"
+            >
+              <CalendarDays size={14} />
+            </button>
+            {calOpen && (
+              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                >
+                  Google Calendar
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                >
+                  Apple / Outlook (.ics)
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="relative" ref={sendRef}>
+            <button
+              className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+              onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+              title="Send / share event"
+            >
+              {showCheck ? <Check size={14} /> : <Send size={14} />}
+            </button>
+            {sendOpen && (
+              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={handleCopyText}
+                >
+                  Copy text
+                </button>
+                <button
+                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                  onClick={handleSendInvite}
+                >
+                  Calendar invite
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
       {primaryUrl ? (
         <a
           href={primaryUrl}

--- a/frontend/src/lib/calendarUtils.js
+++ b/frontend/src/lib/calendarUtils.js
@@ -1,0 +1,155 @@
+function toUtcDateStr(isoStr) {
+  return new Date(isoStr).toISOString().slice(0, 10).replace(/-/g, '')
+}
+
+function toUtcDateTimeStr(isoStr) {
+  return new Date(isoStr).toISOString().slice(0, 19).replace(/[-:]/g, '') + 'Z'
+}
+
+function nextDayIso(isoStr) {
+  const d = new Date(isoStr)
+  d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString()
+}
+
+function escapeIcal(str) {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r\n|\n|\r/g, '\\n')
+}
+
+function icalFilename(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 50) + '.ics'
+}
+
+function buildIcalContent(event) {
+  const { id, title, description, start_at, end_at, venue_name, venue_address, all_day, sources } = event
+  const now = new Date().toISOString().slice(0, 19).replace(/[-:]/g, '') + 'Z'
+  const location = [venue_name, venue_address].filter(Boolean).join(', ')
+  const url = sources?.[0]?.source_url || ''
+
+  const dtstart = all_day
+    ? `DTSTART;VALUE=DATE:${toUtcDateStr(start_at)}`
+    : `DTSTART:${toUtcDateTimeStr(start_at)}`
+  const dtend = all_day
+    ? `DTEND;VALUE=DATE:${toUtcDateStr(end_at || nextDayIso(start_at))}`
+    : `DTEND:${toUtcDateTimeStr(end_at || start_at)}`
+
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//whats-up-madison//Events//EN',
+    'BEGIN:VEVENT',
+    `UID:${id}@whats-up-madison`,
+    `DTSTAMP:${now}`,
+    dtstart,
+    dtend,
+    `SUMMARY:${escapeIcal(title)}`,
+    description ? `DESCRIPTION:${escapeIcal(description)}` : null,
+    location ? `LOCATION:${escapeIcal(location)}` : null,
+    url ? `URL:${url}` : null,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].filter(Boolean).join('\r\n')
+}
+
+const TZ = 'America/Chicago'
+
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  timeZone: TZ,
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+const timeFmt = new Intl.DateTimeFormat('en-US', {
+  timeZone: TZ,
+  hour: 'numeric',
+  minute: '2-digit',
+})
+
+export function formatEventText(event) {
+  const { title, start_at, end_at, all_day, venue_name, venue_address, description, sources } = event
+  const dateStr = dateFmt.format(new Date(start_at))
+  const timeStr = all_day
+    ? 'All day'
+    : end_at
+      ? `${timeFmt.format(new Date(start_at))} – ${timeFmt.format(new Date(end_at))}`
+      : timeFmt.format(new Date(start_at))
+  const location = [venue_name, venue_address].filter(Boolean).join(', ')
+  const url = sources?.[0]?.source_url
+  return [
+    title,
+    `${dateStr} · ${timeStr}`,
+    location || null,
+    description ? `\n${description}` : null,
+    url ? `\n${url}` : null,
+  ].filter(Boolean).join('\n')
+}
+
+export function googleCalendarUrl(event) {
+  const { title, description, start_at, end_at, venue_name, venue_address, all_day } = event
+  let startFmt, endFmt
+  if (all_day) {
+    startFmt = toUtcDateStr(start_at)
+    endFmt = toUtcDateStr(end_at || nextDayIso(start_at))
+  } else {
+    startFmt = toUtcDateTimeStr(start_at)
+    endFmt = toUtcDateTimeStr(end_at || start_at)
+  }
+  const location = [venue_name, venue_address].filter(Boolean).join(', ')
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: title,
+    dates: `${startFmt}/${endFmt}`,
+    details: description || '',
+    location,
+  })
+  return `https://calendar.google.com/calendar/render?${params}`
+}
+
+export function downloadIcal(event) {
+  const content = buildIcalContent(event)
+  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' })
+  const href = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = href
+  a.download = icalFilename(event.title)
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(href)
+}
+
+// Shares a calendar invite (.ics) via the native share sheet on mobile.
+// Falls back to downloading the .ics file on desktop so the user can attach it to an email.
+// Returns { downloaded: true } when the fallback download was used.
+export async function shareCalendarInvite(event) {
+  const content = buildIcalContent(event)
+  const filename = icalFilename(event.title)
+  const blob = new Blob([content], { type: 'text/calendar;charset=utf-8' })
+  const file = new File([blob], filename, { type: 'text/calendar' })
+
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file], title: event.title })
+    } catch {
+      // user dismissed the share sheet
+    }
+    return {}
+  }
+
+  // Desktop fallback: download the .ics so the user can attach it to email
+  const href = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = href
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(href)
+  return { downloaded: true }
+}


### PR DESCRIPTION
## Summary

- Adds **📅 Add to Calendar** dropdown to every event card and all-day card with two options: Google Calendar (opens in new tab) and Apple / Outlook (.ics download)
- Adds **📤 Send** dropdown with two options:
  - **Copy text** — copies a plain-text summary (title, date/time, venue, description, URL) to clipboard; button briefly flashes ✓
  - **Calendar invite** — shares the .ics file via native share sheet on mobile; downloads it on desktop so it can be attached to an email
- Both dropdowns close each other when one is opened; clicking outside closes them
- Icons from `lucide-react` (new dependency); icon buttons use `stopPropagation` so they don't trigger card expand/collapse
- Calendar URL/iCal generation lives in a new `frontend/src/lib/calendarUtils.js` utility

## Test plan

- [ ] Click 📅 on a timed event → dropdown shows "Google Calendar" and "Apple / Outlook (.ics)"
- [ ] "Google Calendar" opens `calendar.google.com` in a new tab with title, time, venue, and description pre-filled
- [ ] "Apple / Outlook (.ics)" downloads a `.ics` file; open it in Apple Calendar or Outlook to confirm event details
- [ ] Click 📤 → dropdown shows "Copy text" and "Calendar invite"
- [ ] "Copy text" copies a readable text blob to clipboard and button flashes ✓
- [ ] "Calendar invite" on desktop downloads a `.ics` file and button flashes ✓; on mobile opens native share sheet
- [ ] Repeat all of the above on an all-day event card (top strip)
- [ ] Opening one dropdown closes the other; clicking outside closes the open dropdown
- [ ] Clicking any dropdown button does not expand/collapse the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)