### PR TITLE
Replace in-place card expansion with modal pop-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ Loaded from `backend/.env` (gitignored). See `backend/.env.example` for required
 
 React + Vite + Tailwind CSS. Node deps are project-local (not in conda).
 
+### Card types
+
+There are two card components: `EventCard` (`frontend/src/components/EventCard.jsx`) for timed events and `AllDayCard` (inside `frontend/src/components/AllDayStrip.jsx`) for all-day / time-varies events. They have different visual weights but share most interaction patterns. When making a UI or behavior change to one, consider whether it applies to the other. It won't always be appropriate to treat them identically, but check both before deciding.
+
 ```
 cd frontend
 npm install      # first time or after package.json changes

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
-import { CalendarDays, Send, Check } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import { CalendarDays, Send, Check, X } from 'lucide-react'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 
 export default function AllDayStrip({ events }) {
@@ -23,7 +24,7 @@ export default function AllDayStrip({ events }) {
 }
 
 function AllDayCard({ event }) {
-  const [expanded, setExpanded] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
   const [calOpen, setCalOpen] = useState(false)
   const [sendOpen, setSendOpen] = useState(false)
   const [showCheck, setShowCheck] = useState(false)
@@ -49,6 +50,15 @@ function AllDayCard({ event }) {
     return () => document.removeEventListener('mousedown', handleOutside)
   }, [sendOpen])
 
+  useEffect(() => {
+    if (!modalOpen) return
+    function handleKey(e) {
+      if (e.key === 'Escape') setModalOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [modalOpen])
+
   function flashCheck() {
     setShowCheck(true)
     setTimeout(() => setShowCheck(false), 1500)
@@ -69,116 +79,244 @@ function AllDayCard({ event }) {
   }
 
   return (
-    <div
-      className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none"
-      onClick={() => setExpanded(e => !e)}
-    >
-      <div className="flex items-start justify-between gap-1">
-        {primary?.source_url ? (
-          <a
-            href={primary.source_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm font-semibold text-gray-900 leading-snug hover:underline line-clamp-2 block flex-1 min-w-0"
-            onClick={e => e.stopPropagation()}
-          >
-            {event.title}
-          </a>
-        ) : (
-          <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 flex-1 min-w-0">{event.title}</h3>
-        )}
-        <div className="flex items-center gap-0.5 flex-shrink-0 ml-1">
-          <div className="relative" ref={calRef}>
-            <button
-              className="text-gray-400 hover:text-gray-600 p-0.5 rounded cursor-pointer"
-              onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-              title="Add to calendar"
-            >
-              <CalendarDays size={13} />
-            </button>
-            {calOpen && (
-              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                >
-                  Google Calendar
-                </button>
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                >
-                  Apple / Outlook (.ics)
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="relative" ref={sendRef}>
-            <button
-              className={`p-0.5 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-              onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-              title="Send / share event"
-            >
-              {showCheck ? <Check size={13} /> : <Send size={13} />}
-            </button>
-            {sendOpen && (
-              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={handleCopyText}
-                >
-                  Copy text
-                </button>
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={handleSendInvite}
-                >
-                  Calendar invite
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-      {event.venue_name && (
-        <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
-      )}
-      {event.description && (
-        <p className={`text-xs text-gray-400 mt-1 whitespace-pre-line ${expanded ? '' : 'line-clamp-1'}`}>
-          {event.description}
-        </p>
-      )}
-      {event.categories?.length > 0 && (
-        <div className="mt-1.5 flex flex-wrap gap-1">
-          {event.categories.map((c) => (
-            <span
-              key={c}
-              className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
-            >
-              {c}
-            </span>
-          ))}
-        </div>
-      )}
-      {event.sources && event.sources.length > 0 && (
-        <div className="mt-1.5 flex flex-wrap gap-2">
-          {event.sources.map((s) => (
+    <>
+      <div
+        className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none"
+        onClick={() => setModalOpen(true)}
+      >
+        <div className="flex items-start justify-between gap-1">
+          {primary?.source_url ? (
             <a
-              key={s.source_name}
-              href={s.source_url}
+              href={primary.source_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs text-blue-600 hover:underline"
+              className="text-sm font-semibold text-gray-900 leading-snug hover:underline line-clamp-2 block flex-1 min-w-0"
               onClick={e => e.stopPropagation()}
             >
-              {s.source_name} ↗
+              {event.title}
             </a>
-          ))}
+          ) : (
+            <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 flex-1 min-w-0">{event.title}</h3>
+          )}
+          <div className="flex items-center gap-0.5 flex-shrink-0 ml-1">
+            <div className="relative" ref={calRef}>
+              <button
+                className="text-gray-400 hover:text-gray-600 p-0.5 rounded cursor-pointer"
+                onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+                title="Add to calendar"
+              >
+                <CalendarDays size={13} />
+              </button>
+              {calOpen && (
+                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                  >
+                    Google Calendar
+                  </button>
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                  >
+                    Apple / Outlook (.ics)
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="relative" ref={sendRef}>
+              <button
+                className={`p-0.5 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+                onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+                title="Send / share event"
+              >
+                {showCheck ? <Check size={13} /> : <Send size={13} />}
+              </button>
+              {sendOpen && (
+                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={handleCopyText}
+                  >
+                    Copy text
+                  </button>
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={handleSendInvite}
+                  >
+                    Calendar invite
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
-      )}
-      <div className="mt-1 flex justify-end">
-        <span className="text-[10px] text-gray-300">{expanded ? '▲' : '▼'}</span>
+        {event.venue_name && (
+          <p className="text-xs text-gray-500 mt-1 truncate">{event.venue_name}</p>
+        )}
+        {event.description && (
+          <p className="text-xs text-gray-400 mt-1 whitespace-pre-line line-clamp-1">
+            {event.description}
+          </p>
+        )}
+        {event.categories?.length > 0 && (
+          <div className="mt-1.5 flex flex-wrap gap-1">
+            {event.categories.map((c) => (
+              <span
+                key={c}
+                className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        )}
+        {event.sources && event.sources.length > 0 && (
+          <div className="mt-1.5 flex flex-wrap gap-2">
+            {event.sources.map((s) => (
+              <a
+                key={s.source_name}
+                href={s.source_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 hover:underline"
+                onClick={e => e.stopPropagation()}
+              >
+                {s.source_name} ↗
+              </a>
+            ))}
+          </div>
+        )}
       </div>
-    </div>
+
+      {modalOpen && createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          onClick={() => setModalOpen(false)}
+        >
+          <div className="absolute inset-0 bg-black/30" />
+          <div
+            className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="px-5 py-4 flex flex-col gap-2">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0">
+                  {primary?.source_url ? (
+                    <a
+                      href={primary.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
+                    >
+                      {event.title}
+                    </a>
+                  ) : (
+                    <h3 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h3>
+                  )}
+                </div>
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                  <div className="relative" ref={calRef}>
+                    <button
+                      className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+                      onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+                      title="Add to calendar"
+                    >
+                      <CalendarDays size={13} />
+                    </button>
+                    {calOpen && (
+                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                        >
+                          Google Calendar
+                        </button>
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                        >
+                          Apple / Outlook (.ics)
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="relative" ref={sendRef}>
+                    <button
+                      className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+                      onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+                      title="Send / share event"
+                    >
+                      {showCheck ? <Check size={13} /> : <Send size={13} />}
+                    </button>
+                    {sendOpen && (
+                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={handleCopyText}
+                        >
+                          Copy text
+                        </button>
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={handleSendInvite}
+                        >
+                          Calendar invite
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
+                    onClick={() => setModalOpen(false)}
+                    title="Close"
+                  >
+                    <X size={13} />
+                  </button>
+                </div>
+              </div>
+              {event.venue_name && (
+                <p className="text-sm text-gray-500">{event.venue_name}</p>
+              )}
+              {event.description && (
+                <div className="mt-1 space-y-2">
+                  {event.description.split('\n\n').map((para, i) => (
+                    <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              )}
+              {event.categories?.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {event.categories.map((c) => (
+                    <span
+                      key={c}
+                      className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {event.sources && event.sources.length > 0 && (
+                <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
+                  {event.sources.map((s) => (
+                    <a
+                      key={s.source_name}
+                      href={s.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-600 hover:underline"
+                    >
+                      {s.source_name} ↗
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
   )
 }

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,10 +1,11 @@
 import { useState, useRef, useEffect } from 'react'
-import { CalendarDays, Send, Check } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import { CalendarDays, Send, Check, X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 
 export default function EventCard({ event }) {
-  const [expanded, setExpanded] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
   const [calOpen, setCalOpen] = useState(false)
   const [sendOpen, setSendOpen] = useState(false)
   const [showCheck, setShowCheck] = useState(false)
@@ -30,6 +31,15 @@ export default function EventCard({ event }) {
     return () => document.removeEventListener('mousedown', handleOutside)
   }, [sendOpen])
 
+  useEffect(() => {
+    if (!modalOpen) return
+    function handleKey(e) {
+      if (e.key === 'Escape') setModalOpen(false)
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [modalOpen])
+
   function flashCheck() {
     setShowCheck(true)
     setTimeout(() => setShowCheck(false), 1500)
@@ -50,125 +60,244 @@ export default function EventCard({ event }) {
   }
 
   return (
-    <div
-      className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none"
-      onClick={() => setExpanded(e => !e)}
-    >
-      <div className="flex items-start justify-between mb-0.5">
-        <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
-        <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
-          <div className="relative" ref={calRef}>
-            <button
-              className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
-              onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-              title="Add to calendar"
-            >
-              <CalendarDays size={14} />
-            </button>
-            {calOpen && (
-              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                >
-                  Google Calendar
-                </button>
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                >
-                  Apple / Outlook (.ics)
-                </button>
-              </div>
-            )}
-          </div>
-          <div className="relative" ref={sendRef}>
-            <button
-              className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-              onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-              title="Send / share event"
-            >
-              {showCheck ? <Check size={14} /> : <Send size={14} />}
-            </button>
-            {sendOpen && (
-              <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={handleCopyText}
-                >
-                  Copy text
-                </button>
-                <button
-                  className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                  onClick={handleSendInvite}
-                >
-                  Calendar invite
-                </button>
-              </div>
-            )}
+    <>
+      <div
+        className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none"
+        onClick={() => setModalOpen(true)}
+      >
+        <div className="flex items-start justify-between mb-0.5">
+          <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
+          <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
+            <div className="relative" ref={calRef}>
+              <button
+                className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+                onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+                title="Add to calendar"
+              >
+                <CalendarDays size={14} />
+              </button>
+              {calOpen && (
+                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                  >
+                    Google Calendar
+                  </button>
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                  >
+                    Apple / Outlook (.ics)
+                  </button>
+                </div>
+              )}
+            </div>
+            <div className="relative" ref={sendRef}>
+              <button
+                className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+                onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+                title="Send / share event"
+              >
+                {showCheck ? <Check size={14} /> : <Send size={14} />}
+              </button>
+              {sendOpen && (
+                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={handleCopyText}
+                  >
+                    Copy text
+                  </button>
+                  <button
+                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                    onClick={handleSendInvite}
+                  >
+                    Calendar invite
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-      {primaryUrl ? (
-        <a
-          href={primaryUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-base font-semibold text-gray-900 leading-snug hover:underline"
-          onClick={e => e.stopPropagation()}
-        >
-          {event.title}
-        </a>
-      ) : (
-        <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
-      )}
-      {event.venue_name && (
-        <p className="text-sm text-gray-500 mt-0.5">{event.venue_name}</p>
-      )}
-      {event.description && (
-        expanded ? (
-          <div className="mt-2 space-y-2">
-            {event.description.split('\n\n').map((para, i) => (
-              <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
-            ))}
-          </div>
+        {primaryUrl ? (
+          <a
+            href={primaryUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-base font-semibold text-gray-900 leading-snug hover:underline"
+            onClick={e => e.stopPropagation()}
+          >
+            {event.title}
+          </a>
         ) : (
+          <h2 className="text-base font-semibold text-gray-900 leading-snug">{event.title}</h2>
+        )}
+        {event.venue_name && (
+          <p className="text-sm text-gray-500 mt-0.5">{event.venue_name}</p>
+        )}
+        {event.description && (
           <p className="text-sm text-gray-600 mt-2 line-clamp-2 whitespace-pre-line">
             {event.description}
           </p>
-        )
-      )}
-      {event.categories?.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {event.categories.map((c) => (
-            <span
-              key={c}
-              className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
-            >
-              {c}
-            </span>
-          ))}
-        </div>
-      )}
-      {event.sources && event.sources.length > 0 && (
-        <div className="mt-auto pt-2 flex flex-wrap gap-2">
-          {event.sources.map((s) => (
-            <a
-              key={s.source_name}
-              href={s.source_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-blue-600 hover:underline"
-              onClick={e => e.stopPropagation()}
-            >
-              {s.source_name} ↗
-            </a>
-          ))}
-        </div>
-      )}
-      <div className="mt-auto pt-1 flex justify-end">
-        <span className="text-[10px] text-gray-300">{expanded ? '▲' : '▼'}</span>
+        )}
+        {event.categories?.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {event.categories.map((c) => (
+              <span
+                key={c}
+                className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        )}
+        {event.sources && event.sources.length > 0 && (
+          <div className="mt-auto pt-2 flex flex-wrap gap-2">
+            {event.sources.map((s) => (
+              <a
+                key={s.source_name}
+                href={s.source_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 hover:underline"
+                onClick={e => e.stopPropagation()}
+              >
+                {s.source_name} ↗
+              </a>
+            ))}
+          </div>
+        )}
       </div>
-    </div>
+
+      {modalOpen && createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          onClick={() => setModalOpen(false)}
+        >
+          <div className="absolute inset-0 bg-black/30" />
+          <div
+            className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="px-5 py-4 flex flex-col gap-2">
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                  <div className="relative" ref={calRef}>
+                    <button
+                      className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+                      onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+                      title="Add to calendar"
+                    >
+                      <CalendarDays size={14} />
+                    </button>
+                    {calOpen && (
+                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                        >
+                          Google Calendar
+                        </button>
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                        >
+                          Apple / Outlook (.ics)
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <div className="relative" ref={sendRef}>
+                    <button
+                      className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+                      onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+                      title="Send / share event"
+                    >
+                      {showCheck ? <Check size={14} /> : <Send size={14} />}
+                    </button>
+                    {sendOpen && (
+                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={handleCopyText}
+                        >
+                          Copy text
+                        </button>
+                        <button
+                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                          onClick={handleSendInvite}
+                        >
+                          Calendar invite
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                  <button
+                    className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
+                    onClick={() => setModalOpen(false)}
+                    title="Close"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              </div>
+              {primaryUrl ? (
+                <a
+                  href={primaryUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
+                >
+                  {event.title}
+                </a>
+              ) : (
+                <h2 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h2>
+              )}
+              {event.venue_name && (
+                <p className="text-sm text-gray-500">{event.venue_name}</p>
+              )}
+              {event.description && (
+                <div className="mt-1 space-y-2">
+                  {event.description.split('\n\n').map((para, i) => (
+                    <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
+                  ))}
+                </div>
+              )}
+              {event.categories?.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {event.categories.map((c) => (
+                    <span
+                      key={c}
+                      className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {event.sources && event.sources.length > 0 && (
+                <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
+                  {event.sources.map((s) => (
+                    <a
+                      key={s.source_name}
+                      href={s.source_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-600 hover:underline"
+                    >
+                      {s.source_name} ↗
+                    </a>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- Clicking an event card now opens a centered modal overlay with the full description and a dimmed backdrop, instead of expanding in place. Click outside or press Escape to dismiss.
- Both `EventCard` and `AllDayCard` use the same modal pattern. The card always shows the collapsed preview (title, venue, truncated description, categories, source links, action buttons).
- Added a note to `AGENTS.md` to check both card types when making UI/behavior changes, since they share most interaction patterns.

## Motivation

In-place expansion caused the entire grid row to grow, pushing all cards below it down regardless of column. The modal approach avoids that while preserving left-to-right chronological ordering in the grid (a masonry layout was tried first but discarded for breaking that ordering).

## Test plan

- [ ] Click a timed event card — modal opens with full description, action buttons, source links; Escape and clicking backdrop both close it
- [ ] Click an all-day card — same behavior
- [ ] Calendar and share dropdowns work from both the card and the modal
- [ ] Grid layout is undisturbed when a modal is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)