### PR TITLE
Fix time bar navigation: scroll to exact hour instead of bucket

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,7 +76,7 @@ export default function App() {
   )
 
   const handleJumpToHour = (hour) => {
-    const el = document.getElementById(bucketForHour(hour))
+    const el = document.getElementById(`hour-${hour}`) ?? document.getElementById(bucketForHour(hour))
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
 

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -1,4 +1,5 @@
 import EventCard from './EventCard'
+import { localHour } from '../lib/eventTime'
 
 const TINTS = {
   morning: 'bg-amber-50 border-amber-200 text-amber-900',
@@ -12,6 +13,14 @@ export default function BucketSection({ id, label, events }) {
 
   const tint = TINTS[id] ?? 'bg-gray-100 border-gray-200 text-gray-800'
 
+  const hourGroups = []
+  for (const event of events) {
+    const h = localHour(event.start_at)
+    const last = hourGroups[hourGroups.length - 1]
+    if (last && last.hour === h) last.events.push(event)
+    else hourGroups.push({ hour: h, events: [event] })
+  }
+
   return (
     <section id={id} className="scroll-mt-32 mt-6 first:mt-2">
       <h2
@@ -22,11 +31,16 @@ export default function BucketSection({ id, label, events }) {
           {events.length} event{events.length === 1 ? '' : 's'}
         </span>
       </h2>
-      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
-        {events.map((event) => (
-          <EventCard key={event.id} event={event} />
-        ))}
-      </div>
+      {hourGroups.map(({ hour, events: hEvents }) => (
+        <div key={hour}>
+          <div id={`hour-${hour}`} className="scroll-mt-40" />
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
+            {hEvents.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+        </div>
+      ))}
     </section>
   )
 }

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -31,8 +31,8 @@ export default function BucketSection({ id, label, events }) {
           {events.length} event{events.length === 1 ? '' : 's'}
         </span>
       </h2>
-      {hourGroups.map(({ hour, events: hEvents }) => (
-        <div key={hour}>
+      {hourGroups.map(({ hour, events: hEvents }, i) => (
+        <div key={hour} className={i > 0 ? 'mt-4 border-t border-gray-200' : ''}>
           <div id={`hour-${hour}`} className="scroll-mt-40" />
           <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
             {hEvents.map((event) => (

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -8,6 +8,12 @@ const TINTS = {
   night: 'bg-slate-100 border-slate-300 text-slate-800',
 }
 
+function formatHour(h) {
+  if (h === 0) return '12 AM'
+  if (h === 12) return '12 PM'
+  return h < 12 ? `${h} AM` : `${h - 12} PM`
+}
+
 export default function BucketSection({ id, label, events }) {
   if (!events || events.length === 0) return null
 
@@ -32,7 +38,14 @@ export default function BucketSection({ id, label, events }) {
         </span>
       </h2>
       {hourGroups.map(({ hour, events: hEvents }, i) => (
-        <div key={hour} className={i > 0 ? 'mt-4 border-t border-gray-200' : ''}>
+        <div key={hour}>
+          {i > 0 && (
+            <div className="flex items-center gap-3 mt-4 mb-1">
+              <div className="flex-1 border-t border-gray-200" />
+              <span className="text-xs text-gray-400">{formatHour(hour)}</span>
+              <div className="flex-1 border-t border-gray-200" />
+            </div>
+          )}
           <div id={`hour-${hour}`} className="scroll-mt-40" />
           <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
             {hEvents.map((event) => (


### PR DESCRIPTION
## Summary

- Clicking a time bar in the density rail previously mapped any hour to a coarse bucket (morning/afternoon/evening/night) and scrolled to the bucket section top — so 8am and 11am both jumped to the same position
- `BucketSection` now groups events by local start hour and renders a zero-height anchor div (`id="hour-N"`, `scroll-mt-40`) before each hourly sub-grid
- `handleJumpToHour` in `App` targets the exact `hour-N` anchor first, with a fallback to the bucket `id` for safety
- `scroll-mt-40` (160px) accounts for the full sticky header stack: app header (48px) + density rail (80px) + bucket h2 (32px)

Closes #12

## Test plan

- [ ] Pick a date with events spread across multiple hours in the same bucket (e.g. several morning hours)
- [ ] Click bars at different hours within the same bucket — each should scroll to a distinct position, not all to the bucket top
- [ ] Verify the first event card is fully visible below the sticky density rail + bucket header (not hidden behind it)
- [ ] Verify bars that span hour boundaries (late night wrapping past midnight) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)