### PR TITLE
Add fuzzy cross-source dedup and source priority ranking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agent Instructions — What's Up Madison
 
+> **CLAUDE.md is a symlink to this file.** Always edit `AGENTS.md` directly — never edit `CLAUDE.md`.
+
 ## Project Overview
 
 Self-populating Madison WI events aggregator. Backend scrapes known sources daily and stores normalized events in PostgreSQL. Frontend shows a date-picker + event card list with click-through to original sources.
@@ -73,7 +75,8 @@ The closed set of event category tags lives in `backend/app/categories.py` (`CAT
 
 All scrapers share `ingest_events(source_name, raw_events, db)`. It handles:
 - **Pre-dedup** — collapses multiple raws sharing a `canonical_hash` from the same run before insert (a source can return e.g. two recurring "Volunteer at Foodbank" series with different IDs but identical title/date/venue); categories are unioned across the duplicates
-- **Upsert** by `canonical_hash` — inserts new events, skips duplicates
+- **Upsert** by `canonical_hash` — inserts new events, skips exact duplicates
+- **Fuzzy dedup** — after an exact hash miss, a secondary search matches candidates by time+venue and scores title similarity via `difflib.SequenceMatcher`; events scoring ≥ `FUZZY_TITLE_THRESHOLD` (0.65) are treated as duplicates and merged rather than inserted as new rows; this catches near-identical events listed under slightly different titles by different sources
 - **Fill-in-nulls** — adds missing scalar fields from later sources; never overwrites set values
 - **Category union** — `RawEvent.categories` are merged into `Event.categories` preserving order, no duplicates; later sources can enrich an earlier one
 - **Multi-source** — one `EventSource` row per (event, source); same event from two scrapers gets two `EventSource` rows, both linked to the same `Event`
@@ -122,6 +125,10 @@ Loaded from `backend/.env` (gitignored). See `backend/.env.example` for required
 ## Frontend
 
 React + Vite + Tailwind CSS. Node deps are project-local (not in conda).
+
+### Source priority
+
+`frontend/src/lib/sources.js` exports `sortedSources(sources)`, which sorts a `sources` array by `SOURCE_PRIORITY` (currently `['Isthmus', 'Visit Madison']`). Both card components use this to determine the title link (first source wins) and footer display order. When adding a new scraper, add it to `SOURCE_PRIORITY` at the appropriate trust rank; sources not in the list sort to the end.
 
 ### Card types
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ whats-up-madison/
 2. Subclass `BaseSource` and implement `fetch() -> list[RawEvent]`
 3. Add an instance to `SCRAPERS` in `backend/app/main.py`
 
-Each `RawEvent` has a `canonical_hash()` method that generates a deduplication key from the normalized title, start date, and venue name. The shared `ingest_events()` function handles upserts, multi-source linking, category merging, and event status tracking automatically.
+Each `RawEvent` has a `canonical_hash()` method that generates a deduplication key from the normalized title, start date, and venue name. After an exact hash miss, `ingest_events()` also runs a fuzzy title-similarity check (anchored by time and venue) to catch near-duplicate events listed under slightly different names by different sources. The shared `ingest_events()` function handles upserts, multi-source linking, category merging, and event status tracking automatically.
 
 If the source has its own category taxonomy that maps cleanly to ours (`backend/app/categories.py`), populate `RawEvent.categories` per event to save LLM cost in the Step 4 tagging pass. Map conservatively — drop ambiguous source categories rather than mis-tagging.
 

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -1,11 +1,15 @@
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
 
+from sqlalchemy import cast, func
+from sqlalchemy import Date as SQLDate
 from sqlalchemy.orm import Session
 
 from app.models import Event, EventSource
 from app.scrapers.base import RawEvent
 
 _FILLABLE_FIELDS = ("description", "end_at", "venue_name", "venue_address", "image_url")
+FUZZY_TITLE_THRESHOLD = 0.65
 
 
 def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> dict:
@@ -22,10 +26,18 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
     # the rest.
     raw_events = _dedupe_by_hash(raw_events)
 
+    # Tracks event_ids for which we've already created/updated an EventSource
+    # for source_name in this run. Needed because fuzzy matching can map two
+    # distinct raws (different canonical_hashes) to the same Event row, which
+    # would otherwise produce a duplicate (event_id, source_name) insert.
+    seen_for_source: set = set()
+
     for raw in raw_events:
         hash_ = raw.canonical_hash()
 
         event = db.query(Event).filter_by(canonical_hash=hash_).first()
+        if event is None:
+            event = _fuzzy_find_event(raw, db)
         if event is None:
             event = Event(
                 title=raw.title,
@@ -67,23 +79,25 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
             if changed:
                 updated += 1
 
-        source = (
-            db.query(EventSource)
-            .filter_by(event_id=event.id, source_name=source_name)
-            .first()
-        )
-        if source is None:
-            db.add(EventSource(
-                event_id=event.id,
-                source_name=source_name,
-                source_url=raw.source_url,
-                last_seen_at=run_start,
-                is_active=True,
-            ))
-        else:
-            source.source_url = raw.source_url
-            source.last_seen_at = run_start
-            source.is_active = True
+        if event.id not in seen_for_source:
+            source = (
+                db.query(EventSource)
+                .filter_by(event_id=event.id, source_name=source_name)
+                .first()
+            )
+            if source is None:
+                db.add(EventSource(
+                    event_id=event.id,
+                    source_name=source_name,
+                    source_url=raw.source_url,
+                    last_seen_at=run_start,
+                    is_active=True,
+                ))
+            else:
+                source.source_url = raw.source_url
+                source.last_seen_at = run_start
+                source.is_active = True
+            seen_for_source.add(event.id)
 
     # Flush pending EventSource inserts so the cleanup queries below can see them
     db.flush()
@@ -113,6 +127,42 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
     db.commit()
 
     return {"inserted": inserted, "updated": updated, "deactivated": deactivated}
+
+
+def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
+    """Return an existing Event that is likely the same real-world event as raw.
+
+    Requires a strong time anchor (exact start_at for timed events, or same
+    date + exact venue for all-day events) plus title similarity ≥ threshold.
+    """
+    raw_venue = (raw.venue_name or "").lower().strip()
+    has_venue = bool(raw_venue)
+
+    # All-day events with no venue have no reliable anchor — skip to avoid false positives.
+    if raw.all_day and not has_venue:
+        return None
+
+    q = db.query(Event).filter(Event.status != "removed")
+    if raw.all_day:
+        q = q.filter(cast(Event.start_at, SQLDate) == raw.start_at.date())
+    else:
+        q = q.filter(Event.start_at == raw.start_at)
+    if has_venue:
+        q = q.filter(func.lower(func.trim(Event.venue_name)) == raw_venue)
+
+    candidates = q.all()
+    if not candidates:
+        return None
+
+    raw_title = raw.title.lower().strip()
+    best: "Event | None" = None
+    best_ratio = 0.0
+    for event in candidates:
+        ratio = SequenceMatcher(None, raw_title, event.title.lower().strip()).ratio()
+        if ratio > best_ratio:
+            best_ratio, best = ratio, event
+
+    return best if best_ratio >= FUZZY_TITLE_THRESHOLD else None
 
 
 def _dedupe_by_hash(raw_events: list[RawEvent]) -> list[RawEvent]:

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { CalendarDays, Send, Check, X } from 'lucide-react'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
+import { sortedSources } from '../lib/sources'
 
 export default function AllDayStrip({ events }) {
   if (!events || events.length === 0) return null
@@ -30,7 +31,8 @@ function AllDayCard({ event }) {
   const [showCheck, setShowCheck] = useState(false)
   const calRef = useRef(null)
   const sendRef = useRef(null)
-  const primary = event.sources?.[0]
+  const sources = sortedSources(event.sources)
+  const primary = sources[0]
 
   useEffect(() => {
     if (!calOpen) return
@@ -171,9 +173,9 @@ function AllDayCard({ event }) {
             ))}
           </div>
         )}
-        {event.sources && event.sources.length > 0 && (
+        {sources.length > 0 && (
           <div className="mt-1.5 flex flex-wrap gap-2">
-            {event.sources.map((s) => (
+            {sources.map((s) => (
               <a
                 key={s.source_name}
                 href={s.source_url}
@@ -297,9 +299,9 @@ function AllDayCard({ event }) {
                   ))}
                 </div>
               )}
-              {event.sources && event.sources.length > 0 && (
+              {sources.length > 0 && (
                 <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
-                  {event.sources.map((s) => (
+                  {sources.map((s) => (
                     <a
                       key={s.source_name}
                       href={s.source_url}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { CalendarDays, Send, Check, X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
+import { sortedSources } from '../lib/sources'
 
 export default function EventCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
@@ -11,7 +12,8 @@ export default function EventCard({ event }) {
   const [showCheck, setShowCheck] = useState(false)
   const calRef = useRef(null)
   const sendRef = useRef(null)
-  const primaryUrl = event.sources?.[0]?.source_url
+  const sources = sortedSources(event.sources)
+  const primaryUrl = sources[0]?.source_url
 
   useEffect(() => {
     if (!calOpen) return
@@ -153,9 +155,9 @@ export default function EventCard({ event }) {
             ))}
           </div>
         )}
-        {event.sources && event.sources.length > 0 && (
+        {sources.length > 0 && (
           <div className="mt-auto pt-2 flex flex-wrap gap-2">
-            {event.sources.map((s) => (
+            {sources.map((s) => (
               <a
                 key={s.source_name}
                 href={s.source_url}
@@ -278,9 +280,9 @@ export default function EventCard({ event }) {
                   ))}
                 </div>
               )}
-              {event.sources && event.sources.length > 0 && (
+              {sources.length > 0 && (
                 <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
-                  {event.sources.map((s) => (
+                  {sources.map((s) => (
                     <a
                       key={s.source_name}
                       href={s.source_url}

--- a/frontend/src/lib/sources.js
+++ b/frontend/src/lib/sources.js
@@ -1,0 +1,10 @@
+const SOURCE_PRIORITY = ['Isthmus', 'Visit Madison']
+
+export function sortedSources(sources) {
+  if (!sources) return []
+  return [...sources].sort((a, b) => {
+    const ai = SOURCE_PRIORITY.indexOf(a.source_name)
+    const bi = SOURCE_PRIORITY.indexOf(b.source_name)
+    return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi)
+  })
+}


### PR DESCRIPTION
Closes #13.

## Summary

- **Fuzzy dedup in `ingest.py`**: after an exact `canonical_hash` miss, `_fuzzy_find_event()` searches for candidates anchored by `start_at` time (or date for all-day events) and venue name, then scores title similarity with `difflib.SequenceMatcher`. Events scoring ≥ 0.65 are merged rather than inserted as new rows, catching near-duplicates across scrapers (e.g. "Boneyard Meat Raffle" listed by both Isthmus and Visit Madison under slightly different titles now appears as one event with two source links). A `seen_for_source` set prevents duplicate `EventSource` inserts when multiple raws from the same scraper fuzzy-match to the same Event.
- **Source priority ranking in the frontend**: new `frontend/src/lib/sources.js` exports `SOURCE_PRIORITY = ['Isthmus', 'Visit Madison']` and `sortedSources()`. Both `EventCard` and `AllDayCard` sort sources before picking the title link and rendering the footer, so the most trusted source always drives the title link regardless of DB insertion order.
- **Docs**: updated `AGENTS.md` (and by symlink `CLAUDE.md`) and `README.md` to document the fuzzy dedup step and source priority convention. Added a prominent note that `CLAUDE.md` is a symlink to `AGENTS.md` and should never be edited directly.

## Test plan

- [ ] Reset DB (`docker compose down -v && docker compose up`) and run `POST /admin/scrape` — no errors
- [ ] `GET /events?date=2026-05-03` returns "Boneyard Meat Raffle" once with both Isthmus and Visit Madison in `sources`
- [ ] Title link on that card points to the Isthmus URL (higher priority)
- [ ] Both source links appear in the card footer, Isthmus listed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)