### PR TITLE
Improve filter visibility and fix sticky header stacking (closes #11)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import DatePicker from './components/DatePicker'
 import DensityRail from './components/DensityRail'
 import AllDayStrip from './components/AllDayStrip'
@@ -38,6 +38,28 @@ export default function App() {
   const [error, setError] = useState(null)
   const [filter, setFilter] = useState(loadFilterState)
   const [hiddenVenues, setHiddenVenues] = useState(new Set())
+
+  const headerRef = useRef(null)
+  const [railEl, setRailEl] = useState(null)
+  const [headerH, setHeaderH] = useState(0)
+  const [railH, setRailH] = useState(0)
+
+  useLayoutEffect(() => {
+    const el = headerRef.current
+    if (!el) return
+    setHeaderH(el.offsetHeight)
+    const ro = new ResizeObserver(() => setHeaderH(el.offsetHeight))
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  useLayoutEffect(() => {
+    if (!railEl) { setRailH(0); return }
+    setRailH(railEl.offsetHeight)
+    const ro = new ResizeObserver(() => setRailH(railEl.offsetHeight))
+    ro.observe(railEl)
+    return () => ro.disconnect()
+  }, [railEl])
 
   useEffect(() => {
     setLoading(true)
@@ -82,8 +104,8 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-3">
+      <div ref={headerRef} className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3">
           <h1 className="text-lg font-bold text-gray-900">What's Up Madison</h1>
           <div className="flex items-center gap-2">
             <CategoryFilter
@@ -122,6 +144,8 @@ export default function App() {
                 )}
               </p>
               <DensityRail
+                ref={setRailEl}
+                stickyTop={headerH}
                 hourCounts={partition.hourCounts}
                 onJumpToHour={handleJumpToHour}
               />
@@ -132,6 +156,7 @@ export default function App() {
                   id={b.id}
                   label={b.label}
                   events={partition[b.id]}
+                  stickyTop={headerH + railH}
                 />
               ))}
             </>

--- a/frontend/src/components/BucketSection.jsx
+++ b/frontend/src/components/BucketSection.jsx
@@ -14,7 +14,7 @@ function formatHour(h) {
   return h < 12 ? `${h} AM` : `${h - 12} PM`
 }
 
-export default function BucketSection({ id, label, events }) {
+export default function BucketSection({ id, label, events, stickyTop }) {
   if (!events || events.length === 0) return null
 
   const tint = TINTS[id] ?? 'bg-gray-100 border-gray-200 text-gray-800'
@@ -28,9 +28,10 @@ export default function BucketSection({ id, label, events }) {
   }
 
   return (
-    <section id={id} className="scroll-mt-32 mt-6 first:mt-2">
+    <section id={id} style={{ scrollMarginTop: stickyTop }} className="mt-6 first:mt-2">
       <h2
-        className={`sticky top-32 z-10 ${tint} border rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between`}
+        style={{ top: stickyTop }}
+        className={`sticky z-10 ${tint} border rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between`}
       >
         <span>{label}</span>
         <span className="text-xs font-normal opacity-70">

--- a/frontend/src/components/CategoryFilter.jsx
+++ b/frontend/src/components/CategoryFilter.jsx
@@ -68,12 +68,22 @@ export default function CategoryFilter({
         className={`px-2 py-1 text-sm rounded border transition-colors flex items-center gap-1 ${
           showBadge
             ? 'border-blue-500 text-blue-700 bg-blue-50 hover:bg-blue-100'
-            : 'border-gray-300 text-gray-700 hover:bg-gray-100'
+            : 'border-gray-400 bg-white text-gray-800 font-medium hover:bg-gray-50'
         }`}
         aria-expanded={open}
         aria-haspopup="dialog"
       >
-        <span>Filter</span>
+        <svg
+          className="w-3.5 h-3.5 flex-shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 4h18M7 8h10M11 12h2M11 16h2" />
+        </svg>
+        <span>Categories</span>
         {showBadge && (
           <span className="text-[10px] px-1 py-0.5 rounded-full bg-blue-600 text-white leading-none">
             {hiddenCount} hidden
@@ -85,7 +95,7 @@ export default function CategoryFilter({
         <div
           role="dialog"
           aria-label="Filter by category"
-          className="absolute right-0 mt-2 w-80 sm:w-96 bg-white border border-gray-200 rounded-lg shadow-lg p-3 z-40"
+          className="absolute left-0 sm:left-auto sm:right-0 mt-2 w-80 sm:w-96 bg-white border border-gray-200 rounded-lg shadow-lg p-3 z-40"
         >
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">

--- a/frontend/src/components/DensityRail.jsx
+++ b/frontend/src/components/DensityRail.jsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react'
+
 const HOUR_TICKS = [
   { hour: 5, label: '5a' },
   { hour: 8, label: '8a' },
@@ -10,13 +12,13 @@ const HOUR_TICKS = [
 
 const ORDER = [...Array(19).keys()].map((i) => i + 5).concat([0, 1, 2, 3, 4])
 
-export default function DensityRail({ hourCounts, onJumpToHour }) {
+const DensityRail = forwardRef(function DensityRail({ hourCounts, onJumpToHour, stickyTop }, ref) {
   const max = Math.max(1, ...hourCounts)
   const total = hourCounts.reduce((a, b) => a + b, 0)
   if (total === 0) return null
 
   return (
-    <div className="sticky top-12 z-20 bg-gray-50/90 backdrop-blur border-b border-gray-200 -mx-4 px-4 py-2">
+    <div ref={ref} style={{ top: stickyTop }} className="sticky z-20 bg-gray-50 backdrop-blur border-b border-gray-200 -mx-4 px-4 py-2">
       <div className="relative flex gap-px h-12">
         {ORDER.map((h) => {
           const count = hourCounts[h]
@@ -63,7 +65,9 @@ export default function DensityRail({ hourCounts, onJumpToHour }) {
       </div>
     </div>
   )
-}
+})
+
+export default DensityRail
 
 function formatHourLabel(h) {
   if (h === 0) return '12a'

--- a/frontend/src/components/VenueFilter.jsx
+++ b/frontend/src/components/VenueFilter.jsx
@@ -77,7 +77,7 @@ export default function VenueFilter({ allVenues, hiddenVenues, onChange }) {
         <div
           role="dialog"
           aria-label="Filter by venue"
-          className="absolute right-0 mt-2 w-72 sm:w-80 bg-white border border-gray-200 rounded-lg shadow-lg p-3 z-40"
+          className="absolute left-0 sm:left-auto sm:right-0 mt-2 w-72 sm:w-80 bg-white border border-gray-200 rounded-lg shadow-lg p-3 z-40"
         >
           <div className="flex items-center justify-between mb-2">
             <p className="text-xs font-semibold text-gray-700 uppercase tracking-wide">


### PR DESCRIPTION
## Summary

- **CategoryFilter button**: added funnel icon, renamed label to "Categories", gave the default state a more prominent appearance (white bg, stronger border, medium weight) so it reads as a distinct interactive control rather than a greyed-out element
- **Mobile header layout**: switched to two-row layout on narrow screens (title on its own row, controls below) so the three buttons aren't cramped on a Pixel 9 / similar viewport; single-row layout preserved on `sm:` and above
- **Dropdown positioning**: both CategoryFilter and VenueFilter dropdowns now open rightward (`left-0`) on mobile (where controls are on the left) and leftward (`right-0`) on desktop — prevents dropdowns going off-screen
- **Sticky stack made dynamic**: header, DensityRail, and BucketSection sticky offsets are now computed via `ResizeObserver` + `useLayoutEffect` rather than hardcoded pixel values, so they stay gapless at any screen size

## Test plan

- [ ] Desktop (>640px): "Categories" button shows funnel icon and new label; default state is visually distinct; active state (non-default filter) still shows blue badge; dropdown opens leftward and stays on screen
- [ ] Mobile (<640px): header shows title on top row, controls on second row; filter dropdowns open rightward and fit within the viewport
- [ ] Scroll down on desktop and mobile: no gap between title bar → hour bar → Morning/Afternoon/Evening/Night bar at any scroll position
- [ ] Resize the window between narrow and wide: sticky offsets adjust automatically with no gaps appearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)