### PR TITLE
Enrich short Isthmus descriptions from event detail pages (closes #16)

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timezone
 from difflib import SequenceMatcher
 
@@ -7,6 +8,8 @@ from sqlalchemy.orm import Session
 
 from app.models import Event, EventSource
 from app.scrapers.base import RawEvent
+
+logger = logging.getLogger(__name__)
 
 _FILLABLE_FIELDS = ("description", "end_at", "venue_name", "venue_address", "image_url")
 FUZZY_TITLE_THRESHOLD = 0.65
@@ -126,7 +129,9 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
 
     db.commit()
 
-    return {"inserted": inserted, "updated": updated, "deactivated": deactivated}
+    stats = {"inserted": inserted, "updated": updated, "deactivated": deactivated}
+    logger.info("%s ingest: %s", source_name, stats)
+    return stats
 
 
 def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
@@ -162,7 +167,12 @@ def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
         if ratio > best_ratio:
             best_ratio, best = ratio, event
 
-    return best if best_ratio >= FUZZY_TITLE_THRESHOLD else None
+    if best_ratio >= FUZZY_TITLE_THRESHOLD:
+        logger.debug(
+            "Fuzzy match (%.2f): '%s' → '%s'", best_ratio, raw.title, best.title
+        )
+        return best
+    return None
 
 
 def _dedupe_by_hash(raw_events: list[RawEvent]) -> list[RawEvent]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+import logging
+import logging.config
+
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
@@ -9,6 +12,33 @@ from app.routers import events
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.visit_madison import VisitMadisonSource
 from app.tagger import tag_untagged_events
+
+logging.config.dictConfig({
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "app": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "app",
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "loggers": {
+        "app": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+            "propagate": False,
+        }
+    },
+})
+
+logger = logging.getLogger(__name__)
 
 Base.metadata.create_all(bind=engine)
 
@@ -35,12 +65,15 @@ def health():
 def trigger_scrape(db: Session = Depends(get_db)):
     results = {}
     for scraper in SCRAPERS:
+        logger.info("Starting scrape: %s", scraper.name)
         try:
             raw = scraper.fetch()
             stats = ingest_events(scraper.name, raw, db)
             results[scraper.name] = stats
+            logger.info("Scrape complete: %s — %s", scraper.name, stats)
         except Exception as e:
             results[scraper.name] = {"error": str(e)}
+            logger.warning("Scrape failed: %s — %s", scraper.name, e)
     try:
         results["_tagging"] = tag_untagged_events(db)
     except Exception as e:

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -1,3 +1,5 @@
+import logging
+import time
 import xml.etree.ElementTree as ET
 from datetime import date, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
@@ -5,14 +7,34 @@ from zoneinfo import ZoneInfo
 
 import httpx
 import recurring_ical_events
+from bs4 import BeautifulSoup
 from icalendar import Calendar
 
-from app.scrapers.base import BaseSource, RawEvent
+from app.scrapers.base import BaseSource, RawEvent, clean_html_text
+
+logger = logging.getLogger(__name__)
 
 _ICAL_URL = "https://isthmus.com/search/event/calendar-of-events/calendar.ics"
 _RSS_BASE = "https://isthmus.com/search/event/calendar-of-events/index.rss"
 _CENTRAL = ZoneInfo("America/Chicago")
 _WINDOW_DAYS = 30
+_DESC_MIN_LEN = 80
+_FETCH_DELAY = 0.5  # seconds between detail-page fetches
+
+
+def _fetch_full_description(url: str) -> str | None:
+    try:
+        resp = httpx.get(url, timeout=15)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.content, "lxml")
+        content = soup.find(id="content")
+        if not content:
+            logger.warning("No id='content' element at %s", url)
+            return None
+        return clean_html_text(content.get_text()) or None
+    except Exception as exc:
+        logger.warning("Failed to fetch description from %s: %s", url, exc)
+        return None
 
 
 class IsthmusSource(BaseSource):
@@ -106,6 +128,7 @@ def _parse_ical(
     cal = Calendar.from_ical(resp.content)
 
     events = []
+    short_count = enriched_count = failed_count = 0
     for comp in recurring_ical_events.of(cal).between(start, end):
         title = str(comp.get("SUMMARY", "")).strip()
         if not title:
@@ -132,6 +155,16 @@ def _parse_ical(
         if not source_url:
             continue
 
+        if len(description or "") < _DESC_MIN_LEN:
+            short_count += 1
+            enriched = _fetch_full_description(source_url)
+            if enriched:
+                description = enriched
+                enriched_count += 1
+            else:
+                failed_count += 1
+            time.sleep(_FETCH_DELAY)
+
         events.append(RawEvent(
             title=title,
             start_at=start_at,
@@ -142,4 +175,9 @@ def _parse_ical(
             source_url=source_url,
         ))
 
+    if short_count:
+        logger.info(
+            "Description enrichment: %d/%d fetched successfully, %d failed",
+            enriched_count, short_count, failed_count,
+        )
     return events


### PR DESCRIPTION
## Summary

- Isthmus scraper now fetches the event detail page for any event whose description is under 80 chars, extracting full text from `id="content"` via BeautifulSoup/lxml; falls back to the original short description on any error
- Adds a 0.5s delay between page fetches to avoid hammering Isthmus (~100 requests/run)
- Adds structured logging across the backend so scrape activity is visible in Docker logs

## Logging added

- `app.main`: INFO on scrape start/complete/fail per scraper
- `app.scrapers.isthmus`: INFO enrichment summary after each run (`N/M fetched, K failed`); WARNING when a fetch fails or `id="content"` is missing (site redesign signal)
- `app.ingest`: INFO with inserted/updated/deactivated counts per source; DEBUG per fuzzy dedup match (title → matched title, similarity score)

## Test plan

- [x] Rebuilt stack with fresh DB (`docker compose down -v && docker compose up --build`)
- [x] Triggered scrape; logs confirmed `100/101 fetched successfully, 1 failed` for Isthmus
- [x] Ingest stats: 155 Isthmus events inserted, 465 Visit Madison inserted
- [x] Fuzzy dedup matches logged correctly (5 cross-source matches, all legitimate)
- [x] Linter clean (`ruff check backend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)