### PR TITLE
Add geographic map view of events (closes #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ frontend/.vite/
 # Local machine-specific
 local_management/
 .claude_scripts/
+.claude/
 
 # OS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,17 @@ Only `status = 'active'` events are returned.
 - All primary keys are UUIDs.
 - Session uses `autoflush=False` — call `db.flush()` explicitly before bulk update queries that need to see pending inserts.
 
+### Geocoding (`backend/app/geocoding.py`, `geocode_runner.py`)
+
+After each scraper runs inside `POST /admin/scrape`, a geocoding pass populates `Event.latitude`/`longitude` for any active event from that source that doesn't yet have coordinates. Results are cached in the `venue_geocodes` table keyed by a normalized lookup string, so two events at the same venue cost one Nominatim request and re-scrapes cost ~0 network calls.
+
+- Geocoder: Nominatim (OpenStreetMap). Free, but ToS requires (a) max 1 req/sec — enforced via a module-level lock in `geocoding.py`, (b) a real `User-Agent` with contact info, (c) attribution on rendered tiles (handled by Leaflet's default attribution control).
+- Address-form lookups query free-text bounded to a Madison bbox. Venue-name-only lookups (mostly Isthmus, no street address) append `", madison, wi"` to the name and use the same bbox-bounded query. **Do not** combine `q` with structured `city`/`state`/`country` params — Nominatim returns 400.
+- Failed lookups (`status=not_found|error`) are also cached so we don't retry every run. To retry them, hit `POST /admin/geocode?force=true` (clears non-success rows from `venue_geocodes` and re-runs the missing set).
+- For backfill or one-off geocodes outside a scrape, use `POST /admin/geocode`. Cache makes it near-instant when warm.
+
+Scrapers don't need to do anything special — populating `RawEvent.venue_address` (preferred) or `RawEvent.venue_name` is enough for the geocoder to attempt a lookup.
+
 ### Environment Variables
 
 Loaded from `backend/.env` (gitignored). See `backend/.env.example` for required keys. Never hardcode credentials.
@@ -133,6 +144,12 @@ React + Vite + Tailwind CSS. Node deps are project-local (not in conda).
 ### Card types
 
 There are two card components: `EventCard` (`frontend/src/components/EventCard.jsx`) for timed events and `AllDayCard` (inside `frontend/src/components/AllDayStrip.jsx`) for all-day / time-varies events. They have different visual weights but share most interaction patterns. When making a UI or behavior change to one, consider whether it applies to the other. It won't always be appropriate to treat them identically, but check both before deciding.
+
+The expanded-detail modal is shared: `frontend/src/components/EventModal.jsx` is rendered by both card components and by `MapView` pin popups. Modal-related changes (layout, share/calendar buttons, Escape behavior, etc.) belong in `EventModal.jsx` so all three callers stay in sync. Note: `EventModal` uses an inline `zIndex: 10000` rather than a Tailwind `z-*` class so it renders above Leaflet's panes (which go up to ~700).
+
+### List vs Map view
+
+The header has a List/Map segmented toggle. Both views consume the same `filteredEvents` array from `App.jsx`, so date / category / venue filters apply identically to both. View mode is persisted to localStorage under `whats-up-madison.viewMode`. List view renders the time-bucketed sections + density rail; map view renders `MapView.jsx` (Leaflet + react-leaflet, with `react-leaflet-cluster` for low-zoom clustering). Pins group co-located events (lat/lng to 5 decimal places ≈ 1m) into a single marker with a count badge; multi-event popups list `time — title` rows that each open `EventModal`. Events without coordinates are surfaced in a collapsible "events without a location" panel below the map so they're never dropped from view. When adding a new filter or selection that should affect the visible event set, apply it to `filteredEvents` in `App.jsx` and both views pick it up automatically.
 
 ```
 cd frontend
@@ -155,7 +172,10 @@ npm run build    # production build
 curl -X POST http://localhost:8000/admin/scrape
 ```
 
-Returns per-scraper stats: `{"Isthmus": {"inserted": N, "updated": N, "deactivated": N}}`.
+Returns per-scraper stats including ingestion + geocoding:
+`{"Isthmus": {"inserted": N, "updated": N, "deactivated": N, "geocoded": N, "geocode_misses": N, "geocode_skipped": N}}`.
+
+To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost:8000/admin/geocode'` (add `?force=true` to clear non-success cache rows and retry previously-failed lookups).
 
 ## Current Build Status
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # What's Up Madison
 
-A self-populating events calendar for Madison, WI. Automatically aggregates events from local venues, publications, and calendars — no manual entry required. Browse by date, see what's on, click through to the original source.
+A self-populating events calendar for Madison, WI. Automatically aggregates events from local venues, publications, and calendars — no manual entry required. Browse by date as a time-bucketed list or as a map of where things are happening, and click through to the original source.
 
 ## Architecture
 
 - **Backend:** Python / FastAPI + PostgreSQL (SQLAlchemy ORM)
-- **Frontend:** React / Vite + Tailwind CSS (date picker + event card list)
+- **Frontend:** React / Vite + Tailwind CSS — date picker + List/Map toggle (Leaflet + OpenStreetMap tiles)
 - **Scrapers:** per-source plugins (API, iCal, HTML) run on a daily schedule
+- **Geocoding:** Nominatim (free, OpenStreetMap), cached per venue so re-scrapes cost ~0 network calls
 - **Local dev:** Docker Compose
 
 ## Getting Started
@@ -70,26 +71,31 @@ This runs all registered scrapers and populates the database. APScheduler (daily
 whats-up-madison/
 ├── backend/
 │   ├── app/
-│   │   ├── main.py          # FastAPI app entry point + /admin/scrape
-│   │   ├── models.py        # SQLAlchemy models (Event, EventSource, Source)
-│   │   ├── schemas.py       # Pydantic response schemas
-│   │   ├── ingest.py        # Shared scraper ingestion utility
+│   │   ├── main.py             # FastAPI app entry point + /admin/scrape, /admin/geocode
+│   │   ├── models.py           # SQLAlchemy models (Event, EventSource, Source, VenueGeocode)
+│   │   ├── schemas.py          # Pydantic response schemas
+│   │   ├── ingest.py           # Shared scraper ingestion utility
+│   │   ├── geocoding.py        # Nominatim wrapper (throttle, User-Agent, Madison bbox, cache)
+│   │   ├── geocode_runner.py   # Per-source and backfill geocoding passes
 │   │   ├── routers/
-│   │   │   └── events.py    # GET /events?date=YYYY-MM-DD
+│   │   │   └── events.py       # GET /events?date=YYYY-MM-DD
 │   │   └── scrapers/
-│   │       ├── base.py      # RawEvent dataclass + BaseSource interface
+│   │       ├── base.py         # RawEvent dataclass + BaseSource interface
 │   │       ├── isthmus.py
-│   │       └── ...          # one module per source
+│   │       └── ...             # one module per source
 │   ├── Dockerfile
 │   └── requirements.txt
-├── frontend/                # React / Vite + Tailwind CSS
+├── frontend/                   # React / Vite + Tailwind CSS
 │   └── src/
-│       ├── App.jsx
+│       ├── App.jsx             # date picker, filters, List/Map toggle
 │       └── components/
 │           ├── DatePicker.jsx
-│           └── EventCard.jsx
+│           ├── EventCard.jsx
+│           ├── AllDayStrip.jsx
+│           ├── EventModal.jsx  # shared expanded-detail modal (used by both card types and MapView)
+│           └── MapView.jsx     # Leaflet map of events with clustered + multi-event pins
 ├── docker-compose.yml
-└── local_management/        # gitignored — machine-local notes and commands
+└── local_management/           # gitignored — machine-local notes and commands
 ```
 
 ## Roadmap
@@ -98,6 +104,7 @@ whats-up-madison/
 - **Step 2 — First scraper + frontend** ✅ Multi-source data model (`Event`/`EventSource`), ingestion utility, React/Vite/Tailwind frontend with date picker and event cards
 - **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); Eventbrite API, City of Madison, individual venue HTML scrapers, APScheduler for daily runs still planned
 - **Step 4 — Categories** 🔄 Closed taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source taxonomy; frontend filter UI shipped (multi-select tag cloud, sensible defaults, localStorage); LLM-assisted tagging pass still planned to fill in Isthmus + future sources
+- **Step 5 — Map view** ✅ Geocoding pipeline (Nominatim, cached per venue in `venue_geocodes` so re-scrapes are free) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve
 
 ## Adding a Scraper
 
@@ -108,6 +115,8 @@ whats-up-madison/
 Each `RawEvent` has a `canonical_hash()` method that generates a deduplication key from the normalized title, start date, and venue name. After an exact hash miss, `ingest_events()` also runs a fuzzy title-similarity check (anchored by time and venue) to catch near-duplicate events listed under slightly different names by different sources. The shared `ingest_events()` function handles upserts, multi-source linking, category merging, and event status tracking automatically.
 
 If the source has its own category taxonomy that maps cleanly to ours (`backend/app/categories.py`), populate `RawEvent.categories` per event to save LLM cost in the Step 4 tagging pass. Map conservatively — drop ambiguous source categories rather than mis-tagging.
+
+Geocoding happens automatically after each scrape via Nominatim, with results cached per venue in the `venue_geocodes` table — scrapers don't need to do anything special. Populate `RawEvent.venue_address` (preferred) or `RawEvent.venue_name` and the geocoder will attempt to resolve coordinates for the map view.
 
 ## API
 
@@ -128,6 +137,8 @@ Returns active events for a given date. Long-running events appear on every date
     "end_at": null,
     "venue_name": "The Sylvee",
     "venue_address": "25 S Livingston St, Madison, WI",
+    "latitude": 43.0731,
+    "longitude": -89.3820,
     "categories": [],
     "status": "active",
     "sources": [
@@ -138,6 +149,12 @@ Returns active events for a given date. Long-running events appear on every date
 ]
 ```
 
+`latitude` and `longitude` are populated by the geocoder when a Nominatim lookup for the venue succeeds; they are `null` for events whose venue couldn't be resolved (those events still appear in the list view and in a "without a location" panel under the map).
+
 ### `POST /admin/scrape`
 
-Triggers all registered scrapers and ingests results. Returns per-source stats.
+Triggers all registered scrapers and ingests results. After each scraper, also runs a geocoding pass for any newly-active events from that source that don't yet have coordinates. Returns per-source stats including ingestion (`inserted`, `updated`, `deactivated`) and geocoding (`geocoded`, `geocode_misses`, `geocode_skipped`).
+
+### `POST /admin/geocode`
+
+Backfill or retry geocoding outside a scrape. Optional `force=true` clears non-success rows from the `venue_geocodes` cache so previously-failed lookups get retried.

--- a/backend/app/geocode_runner.py
+++ b/backend/app/geocode_runner.py
@@ -1,0 +1,104 @@
+import logging
+import time
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.geocoding import geocode_event
+from app.models import Event, EventSource, VenueGeocode
+
+logger = logging.getLogger(__name__)
+
+
+def _missing_coords_query(db: Session):
+    return (
+        db.query(Event)
+        .filter(
+            Event.status == "active",
+            Event.latitude.is_(None),
+            or_(Event.venue_address.isnot(None), Event.venue_name.isnot(None)),
+        )
+    )
+
+
+def geocode_missing_for_source(source_name: str, db: Session) -> dict:
+    """Geocode active events from a given source that don't yet have coordinates."""
+    candidates = (
+        _missing_coords_query(db)
+        .join(EventSource, EventSource.event_id == Event.id)
+        .filter(EventSource.source_name == source_name, EventSource.is_active.is_(True))
+        .distinct()
+        .all()
+    )
+
+    hits = 0
+    misses = 0
+    skipped = 0
+    for event in candidates:
+        try:
+            updated = geocode_event(event, db)
+        except Exception as e:
+            logger.warning("Geocode failed for event %s: %s", event.id, e)
+            misses += 1
+            continue
+        if updated:
+            hits += 1
+        elif event.venue_name or event.venue_address:
+            misses += 1
+        else:
+            skipped += 1
+
+    if hits:
+        db.commit()
+
+    return {
+        "geocoded": hits,
+        "geocode_misses": misses,
+        "geocode_skipped": skipped,
+    }
+
+
+def geocode_all_missing(db: Session, force: bool = False) -> dict:
+    """Backfill: geocode every active event missing coordinates. If force, retry failed lookups."""
+    started = time.monotonic()
+
+    cleared_failed = 0
+    if force:
+        cleared_failed = (
+            db.query(VenueGeocode)
+            .filter(VenueGeocode.status != "success")
+            .delete(synchronize_session=False)
+        )
+        db.commit()
+
+    candidates = _missing_coords_query(db).all()
+
+    hits = 0
+    misses = 0
+    skipped = 0
+    errors = 0
+    for event in candidates:
+        try:
+            updated = geocode_event(event, db)
+        except Exception as e:
+            logger.warning("Geocode failed for event %s: %s", event.id, e)
+            errors += 1
+            continue
+        if updated:
+            hits += 1
+        elif event.venue_name or event.venue_address:
+            misses += 1
+        else:
+            skipped += 1
+
+    if hits:
+        db.commit()
+
+    return {
+        "events_updated": hits,
+        "misses": misses,
+        "skipped": skipped,
+        "errors": errors,
+        "cleared_failed_cache": cleared_failed,
+        "duration_seconds": round(time.monotonic() - started, 1),
+    }

--- a/backend/app/geocoding.py
+++ b/backend/app/geocoding.py
@@ -1,0 +1,138 @@
+import logging
+import re
+import threading
+import time
+from typing import Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.models import Event, VenueGeocode
+
+logger = logging.getLogger(__name__)
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
+USER_AGENT = "whats-up-madison/0.1 (andrew.eric.maier@gmail.com)"
+
+# Bounding box around Madison, WI used to bias address-form lookups.
+# Order matches Nominatim's viewbox param: left,top,right,bottom (lng,lat,lng,lat).
+MADISON_VIEWBOX = "-89.6,43.18,-89.20,42.95"
+
+MIN_INTERVAL_SECONDS = 1.05  # Nominatim ToS: max 1 request/second
+REQUEST_TIMEOUT_SECONDS = 10.0
+
+# "<name> | madison, wi" marks a venue-name-only lookup so geocode_lookup can
+# route the request to the structured (city/state) form rather than free-text q.
+_NAME_SEPARATOR = " | "
+_MADISON_SUFFIX = ", madison, wi"
+
+_throttle_lock = threading.Lock()
+_last_call_at: float = 0.0
+
+
+def normalize_lookup(venue_name: Optional[str], venue_address: Optional[str]) -> Optional[str]:
+    """Build a stable cache key from whatever venue info we have."""
+    if venue_address and venue_address.strip():
+        addr = re.sub(r"\s+", " ", venue_address.strip().lower())
+        if "madison" not in addr:
+            addr = f"{addr}{_MADISON_SUFFIX}"
+        return addr
+    if venue_name and venue_name.strip():
+        name = re.sub(r"\s+", " ", venue_name.strip().lower())
+        return f"{name}{_NAME_SEPARATOR}madison, wi"
+    return None
+
+
+def _throttle() -> None:
+    global _last_call_at
+    with _throttle_lock:
+        elapsed = time.monotonic() - _last_call_at
+        if elapsed < MIN_INTERVAL_SECONDS:
+            time.sleep(MIN_INTERVAL_SECONDS - elapsed)
+        _last_call_at = time.monotonic()
+
+
+def _call_nominatim(lookup_key: str) -> tuple[str, Optional[dict]]:
+    """Returns (status, result_dict_or_None). status is success|not_found|error."""
+    # Nominatim rejects `q` combined with structured params (city/state/country),
+    # so always use free-text `q` and bias to Madison via the viewbox bbox.
+    if _NAME_SEPARATOR in lookup_key:
+        name, _, _suffix = lookup_key.partition(_NAME_SEPARATOR)
+        q = f"{name}, madison, wi"
+    else:
+        q = lookup_key
+
+    params = {
+        "q": q,
+        "viewbox": MADISON_VIEWBOX,
+        "bounded": "1",
+        "format": "json",
+        "limit": "1",
+    }
+
+    _throttle()
+    try:
+        resp = httpx.get(
+            NOMINATIM_URL,
+            params=params,
+            headers={"User-Agent": USER_AGENT},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+    except Exception as e:
+        logger.warning("Geocoder error for %r: %s", lookup_key, e)
+        return "error", None
+
+    data = resp.json()
+    if not data:
+        return "not_found", None
+    return "success", data[0]
+
+
+def geocode_lookup(lookup_key: str, db: Session) -> Optional[tuple[float, float]]:
+    """Return cached or freshly-fetched (lat, lng) for a lookup key, or None."""
+    cached = db.query(VenueGeocode).filter(VenueGeocode.lookup_key == lookup_key).first()
+    if cached is not None:
+        if cached.status == "success" and cached.latitude is not None and cached.longitude is not None:
+            return (cached.latitude, cached.longitude)
+        return None
+
+    status, result = _call_nominatim(lookup_key)
+    row = VenueGeocode(
+        lookup_key=lookup_key,
+        status=status,
+        geocoder="nominatim",
+    )
+    if status == "success" and result is not None:
+        try:
+            row.latitude = float(result["lat"])
+            row.longitude = float(result["lon"])
+            row.display_name = result.get("display_name")
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning("Geocoder bad payload for %r: %s", lookup_key, e)
+            row.status = "error"
+            row.latitude = None
+            row.longitude = None
+
+    db.add(row)
+    # Commit immediately so a crash mid-run doesn't waste rate-limit budget on
+    # a key we already hit the network for.
+    db.commit()
+
+    if row.status == "success" and row.latitude is not None and row.longitude is not None:
+        return (row.latitude, row.longitude)
+    return None
+
+
+def geocode_event(event: Event, db: Session) -> bool:
+    """Set event.latitude/longitude from cache or Nominatim. Returns True on hit."""
+    if event.latitude is not None and event.longitude is not None:
+        return False
+    key = normalize_lookup(event.venue_name, event.venue_address)
+    if key is None:
+        return False
+    coords = geocode_lookup(key, db)
+    if coords is None:
+        return False
+    event.latitude, event.longitude = coords
+    return True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.database import Base, engine, get_db
+from app.geocode_runner import geocode_all_missing, geocode_missing_for_source
 from app.ingest import ingest_events
 from app.routers import events
 from app.scrapers.isthmus import IsthmusSource
@@ -74,6 +75,14 @@ def trigger_scrape(db: Session = Depends(get_db)):
         except Exception as e:
             results[scraper.name] = {"error": str(e)}
             logger.warning("Scrape failed: %s — %s", scraper.name, e)
+            continue
+        try:
+            geo_stats = geocode_missing_for_source(scraper.name, db)
+            results[scraper.name] = {**results[scraper.name], **geo_stats}
+            logger.info("Geocode complete: %s — %s", scraper.name, geo_stats)
+        except Exception as e:
+            results[scraper.name]["geocode_error"] = str(e)
+            logger.warning("Geocode failed: %s — %s", scraper.name, e)
     try:
         results["_tagging"] = tag_untagged_events(db)
     except Exception as e:
@@ -85,5 +94,13 @@ def trigger_scrape(db: Session = Depends(get_db)):
 def trigger_tag(model: str = None, db: Session = Depends(get_db)):
     try:
         return tag_untagged_events(db, model=model)
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@app.post("/admin/geocode")
+def trigger_geocode(force: bool = False, db: Session = Depends(get_db)):
+    try:
+        return geocode_all_missing(db, force=force)
     except Exception as e:
         return {"error": str(e)}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import relationship
 
@@ -16,6 +16,8 @@ class Event(Base):
     end_at = Column(DateTime(timezone=True))
     venue_name = Column(String)
     venue_address = Column(String)
+    latitude = Column(Float)
+    longitude = Column(Float)
     categories = Column(ARRAY(String), default=[])
     image_url = Column(String)
     all_day = Column(Boolean, nullable=False, server_default="false")
@@ -54,3 +56,17 @@ class Source(Base):
     last_run_at = Column(DateTime(timezone=True))
     last_run_status = Column(String)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class VenueGeocode(Base):
+    __tablename__ = "venue_geocodes"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    lookup_key = Column(String, unique=True, nullable=False, index=True)
+    latitude = Column(Float)
+    longitude = Column(Float)
+    display_name = Column(String)
+    status = Column(String, nullable=False)  # success | not_found | error
+    geocoder = Column(String, nullable=False, server_default="nominatim")
+    geocoded_at = Column(DateTime(timezone=True), server_default=func.now())
+    attempts = Column(Integer, nullable=False, server_default="1")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -20,6 +20,8 @@ class EventResponse(BaseModel):
     end_at: Optional[datetime] = None
     venue_name: Optional[str] = None
     venue_address: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
     categories: list[str] = []
     image_url: Optional[str] = None
     all_day: bool = False

--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -183,6 +183,24 @@ Direct sources, generally worth their own scraper for completeness and richer da
 
 ---
 
+## Geocoding
+
+Event coordinates power the map view. The pipeline runs after each scraper inside `POST /admin/scrape` and is also exposed as `POST /admin/geocode` for backfill (`force=true` clears non-success cache rows and retries).
+
+### Nominatim (OpenStreetMap)
+- URL: https://nominatim.openstreetmap.org/search
+- Used by: `backend/app/geocoding.py`
+- Status: **integrated**
+- Notes: Free, open-source geocoder. ToS requires (a) max 1 request/second (enforced via module-level lock in `geocoding.py`), (b) a real `User-Agent` containing contact info (`whats-up-madison/0.1 (andrew.eric.maier@gmail.com)`), and (c) attribution on rendered tiles (handled by Leaflet's default attribution control). Address-form lookups are biased to a Madison bounding box; venue-name-only lookups (mostly Isthmus events with no street address) use structured `city=Madison&state=Wisconsin` params. Results are cached in the `venue_geocodes` table by a normalized lookup key, so re-scrapes cost ~0 network calls. Failed lookups (`status=not_found|error`) are also cached to avoid retry loops.
+
+### Tile provider — OpenStreetMap
+- URL: https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+- Used by: `frontend/src/components/MapView.jsx`
+- Status: **integrated**
+- Notes: Free public OSM tile servers used by the Leaflet map. Attribution is included in the `TileLayer` config per OSM's tile usage policy. If usage grows beyond hobby scale, switch to a hosted provider (MapTiler / Stadia / Mapbox).
+
+---
+
 ## Category Taxonomy
 
 Events are tagged with zero or more categories from a closed vocabulary. The canonical list lives in `backend/app/categories.py` — that module is the source of truth referenced by the LLM tagging pass (Step 4). When the taxonomy changes, update both files together.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,12 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "lucide-react": "^1.14.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "react-leaflet": "^5.0.0",
+        "react-leaflet-cluster": "^4.1.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -623,6 +626,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1984,6 +1998,21 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2789,6 +2818,36 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/react-leaflet-cluster": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-leaflet-cluster/-/react-leaflet-cluster-4.1.3.tgz",
+      "integrity": "sha512-b3ICS7r9Fs5hBWrFPMVnmkCuDewyG3m1GaGzamXY0eryyAXDfQ+ikSkiR/mVethueIIA5MSyLok2/KsZVotspQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "leaflet.markercluster": "^1.5.3"
+      },
+      "peerDependencies": {
+        "@react-leaflet/core": "^3.0.0",
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "lucide-react": "^1.14.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-leaflet": "^5.0.0",
+    "react-leaflet-cluster": "^4.1.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import AllDayStrip from './components/AllDayStrip'
 import BucketSection from './components/BucketSection'
 import CategoryFilter from './components/CategoryFilter'
 import VenueFilter from './components/VenueFilter'
+import MapView from './components/MapView'
 import { partitionEvents } from './lib/eventTime'
 import {
   filterEvents,
@@ -14,6 +15,15 @@ import {
 
 function toLocalDateString(date) {
   return date.toLocaleDateString('en-CA') // YYYY-MM-DD in local time
+}
+
+const VIEW_KEY = 'whats-up-madison.viewMode'
+function loadViewMode() {
+  try {
+    return localStorage.getItem(VIEW_KEY) === 'map' ? 'map' : 'list'
+  } catch {
+    return 'list'
+  }
 }
 
 const BUCKETS = [
@@ -38,6 +48,7 @@ export default function App() {
   const [error, setError] = useState(null)
   const [filter, setFilter] = useState(loadFilterState)
   const [hiddenVenues, setHiddenVenues] = useState(new Set())
+  const [viewMode, setViewMode] = useState(loadViewMode)
 
   const headerRef = useRef(null)
   const [railEl, setRailEl] = useState(null)
@@ -79,6 +90,10 @@ export default function App() {
     saveFilterState(filter)
   }, [filter])
 
+  useEffect(() => {
+    try { localStorage.setItem(VIEW_KEY, viewMode) } catch { /* ignore quota */ }
+  }, [viewMode])
+
   const allVenues = useMemo(() => {
     const names = events.map((e) => e.venue_name).filter(Boolean)
     return [...new Set(names)].sort()
@@ -108,6 +123,22 @@ export default function App() {
         <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3">
           <h1 className="text-lg font-bold text-gray-900">What's Up Madison</h1>
           <div className="flex items-center gap-2">
+            <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
+              <button
+                type="button"
+                onClick={() => setViewMode('list')}
+                className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+              >
+                List
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('map')}
+                className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+              >
+                Map
+              </button>
+            </div>
             <CategoryFilter
               selected={filter.selected}
               includeUncategorized={filter.includeUncategorized}
@@ -143,22 +174,28 @@ export default function App() {
                   <span className="text-gray-400"> of {events.length}</span>
                 )}
               </p>
-              <DensityRail
-                ref={setRailEl}
-                stickyTop={headerH}
-                hourCounts={partition.hourCounts}
-                onJumpToHour={handleJumpToHour}
-              />
-              <AllDayStrip events={partition.allday} />
-              {BUCKETS.map((b) => (
-                <BucketSection
-                  key={b.id}
-                  id={b.id}
-                  label={b.label}
-                  events={partition[b.id]}
-                  stickyTop={headerH + railH}
-                />
-              ))}
+              {viewMode === 'list' ? (
+                <>
+                  <DensityRail
+                    ref={setRailEl}
+                    stickyTop={headerH}
+                    hourCounts={partition.hourCounts}
+                    onJumpToHour={handleJumpToHour}
+                  />
+                  <AllDayStrip events={partition.allday} />
+                  {BUCKETS.map((b) => (
+                    <BucketSection
+                      key={b.id}
+                      id={b.id}
+                      label={b.label}
+                      events={partition[b.id]}
+                      stickyTop={headerH + railH}
+                    />
+                  ))}
+                </>
+              ) : (
+                <MapView events={filteredEvents} stickyTop={headerH} />
+              )}
             </>
           )}
         </div>

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
-import { createPortal } from 'react-dom'
-import { CalendarDays, Send, Check, X } from 'lucide-react'
+import { CalendarDays, Send, Check } from 'lucide-react'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 import { sortedSources } from '../lib/sources'
+import EventModal from './EventModal'
 
 export default function AllDayStrip({ events }) {
   if (!events || events.length === 0) return null
@@ -51,15 +51,6 @@ function AllDayCard({ event }) {
     document.addEventListener('mousedown', handleOutside)
     return () => document.removeEventListener('mousedown', handleOutside)
   }, [sendOpen])
-
-  useEffect(() => {
-    if (!modalOpen) return
-    function handleKey(e) {
-      if (e.key === 'Escape') setModalOpen(false)
-    }
-    document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
-  }, [modalOpen])
 
   function flashCheck() {
     setShowCheck(true)
@@ -191,134 +182,7 @@ function AllDayCard({ event }) {
         )}
       </div>
 
-      {modalOpen && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          onClick={() => setModalOpen(false)}
-        >
-          <div className="absolute inset-0 bg-black/30" />
-          <div
-            className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
-            onClick={e => e.stopPropagation()}
-          >
-            <div className="px-5 py-4 flex flex-col gap-2">
-              <div className="flex items-start justify-between gap-2">
-                <div className="flex-1 min-w-0">
-                  {primary?.source_url ? (
-                    <a
-                      href={primary.source_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
-                    >
-                      {event.title}
-                    </a>
-                  ) : (
-                    <h3 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h3>
-                  )}
-                </div>
-                <div className="flex items-center gap-0.5 flex-shrink-0">
-                  <div className="relative" ref={calRef}>
-                    <button
-                      className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
-                      onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-                      title="Add to calendar"
-                    >
-                      <CalendarDays size={13} />
-                    </button>
-                    {calOpen && (
-                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                        >
-                          Google Calendar
-                        </button>
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                        >
-                          Apple / Outlook (.ics)
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <div className="relative" ref={sendRef}>
-                    <button
-                      className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-                      onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-                      title="Send / share event"
-                    >
-                      {showCheck ? <Check size={13} /> : <Send size={13} />}
-                    </button>
-                    {sendOpen && (
-                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={handleCopyText}
-                        >
-                          Copy text
-                        </button>
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={handleSendInvite}
-                        >
-                          Calendar invite
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
-                    onClick={() => setModalOpen(false)}
-                    title="Close"
-                  >
-                    <X size={13} />
-                  </button>
-                </div>
-              </div>
-              {event.venue_name && (
-                <p className="text-sm text-gray-500">{event.venue_name}</p>
-              )}
-              {event.description && (
-                <div className="mt-1 space-y-2">
-                  {event.description.split('\n\n').map((para, i) => (
-                    <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
-                  ))}
-                </div>
-              )}
-              {event.categories?.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-1">
-                  {event.categories.map((c) => (
-                    <span
-                      key={c}
-                      className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
-                    >
-                      {c}
-                    </span>
-                  ))}
-                </div>
-              )}
-              {sources.length > 0 && (
-                <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
-                  {sources.map((s) => (
-                    <a
-                      key={s.source_name}
-                      href={s.source_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-blue-600 hover:underline"
-                    >
-                      {s.source_name} ↗
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+      {modalOpen && <EventModal event={event} onClose={() => setModalOpen(false)} />}
     </>
   )
 }

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useEffect } from 'react'
-import { createPortal } from 'react-dom'
-import { CalendarDays, Send, Check, X } from 'lucide-react'
+import { CalendarDays, Send, Check } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
 import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 import { sortedSources } from '../lib/sources'
+import EventModal from './EventModal'
 
 export default function EventCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
@@ -32,15 +32,6 @@ export default function EventCard({ event }) {
     document.addEventListener('mousedown', handleOutside)
     return () => document.removeEventListener('mousedown', handleOutside)
   }, [sendOpen])
-
-  useEffect(() => {
-    if (!modalOpen) return
-    function handleKey(e) {
-      if (e.key === 'Escape') setModalOpen(false)
-    }
-    document.addEventListener('keydown', handleKey)
-    return () => document.removeEventListener('keydown', handleKey)
-  }, [modalOpen])
 
   function flashCheck() {
     setShowCheck(true)
@@ -173,133 +164,7 @@ export default function EventCard({ event }) {
         )}
       </div>
 
-      {modalOpen && createPortal(
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          onClick={() => setModalOpen(false)}
-        >
-          <div className="absolute inset-0 bg-black/30" />
-          <div
-            className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
-            onClick={e => e.stopPropagation()}
-          >
-            <div className="px-5 py-4 flex flex-col gap-2">
-              <div className="flex items-start justify-between gap-2">
-                <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
-                <div className="flex items-center gap-0.5 flex-shrink-0">
-                  <div className="relative" ref={calRef}>
-                    <button
-                      className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
-                      onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-                      title="Add to calendar"
-                    >
-                      <CalendarDays size={14} />
-                    </button>
-                    {calOpen && (
-                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                        >
-                          Google Calendar
-                        </button>
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                        >
-                          Apple / Outlook (.ics)
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <div className="relative" ref={sendRef}>
-                    <button
-                      className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-                      onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-                      title="Send / share event"
-                    >
-                      {showCheck ? <Check size={14} /> : <Send size={14} />}
-                    </button>
-                    {sendOpen && (
-                      <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={handleCopyText}
-                        >
-                          Copy text
-                        </button>
-                        <button
-                          className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                          onClick={handleSendInvite}
-                        >
-                          Calendar invite
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
-                    onClick={() => setModalOpen(false)}
-                    title="Close"
-                  >
-                    <X size={14} />
-                  </button>
-                </div>
-              </div>
-              {primaryUrl ? (
-                <a
-                  href={primaryUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
-                >
-                  {event.title}
-                </a>
-              ) : (
-                <h2 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h2>
-              )}
-              {event.venue_name && (
-                <p className="text-sm text-gray-500">{event.venue_name}</p>
-              )}
-              {event.description && (
-                <div className="mt-1 space-y-2">
-                  {event.description.split('\n\n').map((para, i) => (
-                    <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
-                  ))}
-                </div>
-              )}
-              {event.categories?.length > 0 && (
-                <div className="flex flex-wrap gap-1 mt-1">
-                  {event.categories.map((c) => (
-                    <span
-                      key={c}
-                      className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
-                    >
-                      {c}
-                    </span>
-                  ))}
-                </div>
-              )}
-              {sources.length > 0 && (
-                <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
-                  {sources.map((s) => (
-                    <a
-                      key={s.source_name}
-                      href={s.source_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs text-blue-600 hover:underline"
-                    >
-                      {s.source_name} ↗
-                    </a>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+      {modalOpen && <EventModal event={event} onClose={() => setModalOpen(false)} />}
     </>
   )
 }

--- a/frontend/src/components/EventModal.jsx
+++ b/frontend/src/components/EventModal.jsx
@@ -1,0 +1,209 @@
+import { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { CalendarDays, Send, Check, X } from 'lucide-react'
+import { formatTimeRange } from '../lib/eventTime'
+import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
+import { sortedSources } from '../lib/sources'
+
+export default function EventModal({ event, onClose }) {
+  const [calOpen, setCalOpen] = useState(false)
+  const [sendOpen, setSendOpen] = useState(false)
+  const [showCheck, setShowCheck] = useState(false)
+  const calRef = useRef(null)
+  const sendRef = useRef(null)
+  const sources = sortedSources(event.sources)
+  const primaryUrl = sources[0]?.source_url
+
+  useEffect(() => {
+    if (!calOpen) return
+    function handleOutside(e) {
+      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [calOpen])
+
+  useEffect(() => {
+    if (!sendOpen) return
+    function handleOutside(e) {
+      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [sendOpen])
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  function flashCheck() {
+    setShowCheck(true)
+    setTimeout(() => setShowCheck(false), 1500)
+  }
+
+  async function handleCopyText(e) {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(formatEventText(event))
+    setSendOpen(false)
+    flashCheck()
+  }
+
+  async function handleSendInvite(e) {
+    e.stopPropagation()
+    const result = await shareCalendarInvite(event)
+    setSendOpen(false)
+    if (result?.downloaded) flashCheck()
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center p-4"
+      style={{ zIndex: 10000 }}
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/30" />
+      <div
+        className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 flex flex-col gap-2">
+          <div className="flex items-start justify-between gap-2">
+            {event.all_day ? (
+              <div className="flex-1 min-w-0">
+                {primaryUrl ? (
+                  <a
+                    href={primaryUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
+                  >
+                    {event.title}
+                  </a>
+                ) : (
+                  <h3 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h3>
+                )}
+              </div>
+            ) : (
+              <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+            )}
+            <div className="flex items-center gap-0.5 flex-shrink-0">
+              <div className="relative" ref={calRef}>
+                <button
+                  className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+                  onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+                  title="Add to calendar"
+                >
+                  <CalendarDays size={14} />
+                </button>
+                {calOpen && (
+                  <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                    <button
+                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                      onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+                    >
+                      Google Calendar
+                    </button>
+                    <button
+                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                      onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+                    >
+                      Apple / Outlook (.ics)
+                    </button>
+                  </div>
+                )}
+              </div>
+              <div className="relative" ref={sendRef}>
+                <button
+                  className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+                  onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+                  title="Send / share event"
+                >
+                  {showCheck ? <Check size={14} /> : <Send size={14} />}
+                </button>
+                {sendOpen && (
+                  <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+                    <button
+                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                      onClick={handleCopyText}
+                    >
+                      Copy text
+                    </button>
+                    <button
+                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+                      onClick={handleSendInvite}
+                    >
+                      Calendar invite
+                    </button>
+                  </div>
+                )}
+              </div>
+              <button
+                className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
+                onClick={onClose}
+                title="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          </div>
+          {!event.all_day && (
+            primaryUrl ? (
+              <a
+                href={primaryUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-lg font-semibold text-gray-900 leading-snug hover:underline"
+              >
+                {event.title}
+              </a>
+            ) : (
+              <h2 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h2>
+            )
+          )}
+          {event.venue_name && (
+            <p className="text-sm text-gray-500">{event.venue_name}</p>
+          )}
+          {event.description && (
+            <div className="mt-1 space-y-2">
+              {event.description.split('\n\n').map((para, i) => (
+                <p key={i} className="text-sm text-gray-600 whitespace-pre-line">{para}</p>
+              ))}
+            </div>
+          )}
+          {event.categories?.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {event.categories.map((c) => (
+                <span
+                  key={c}
+                  className="text-[11px] px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
+          {sources.length > 0 && (
+            <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
+              {sources.map((s) => (
+                <a
+                  key={s.source_name}
+                  href={s.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline"
+                >
+                  {s.source_name} ↗
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -1,0 +1,207 @@
+import { useState, useMemo } from 'react'
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet'
+import MarkerClusterGroup from 'react-leaflet-cluster'
+import L from 'leaflet'
+import iconRetina from 'leaflet/dist/images/marker-icon-2x.png'
+import iconUrl from 'leaflet/dist/images/marker-icon.png'
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png'
+import { formatTimeRange } from '../lib/eventTime'
+import EventModal from './EventModal'
+
+// Bundlers strip the default marker icon paths; restore them once on import.
+delete L.Icon.Default.prototype._getIconUrl
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: iconRetina,
+  iconUrl,
+  shadowUrl,
+})
+
+const MADISON_CENTER = [43.0731, -89.4012]
+const DEFAULT_ZOOM = 13
+
+function groupByCoord(events) {
+  const groups = new Map()
+  for (const e of events) {
+    if (e.latitude == null || e.longitude == null) continue
+    const key = `${e.latitude.toFixed(5)},${e.longitude.toFixed(5)}`
+    if (!groups.has(key)) {
+      groups.set(key, { key, lat: e.latitude, lng: e.longitude, events: [] })
+    }
+    groups.get(key).events.push(e)
+  }
+  return [...groups.values()]
+}
+
+function makeBadgeIcon(count) {
+  if (count <= 1) return new L.Icon.Default()
+  return L.divIcon({
+    className: 'wum-multi-pin',
+    html: `
+      <div style="position: relative;">
+        <img src="${iconUrl}" style="width: 25px; height: 41px; display: block;" />
+        <div style="
+          position: absolute;
+          top: -4px;
+          right: -8px;
+          background: #2563eb;
+          color: white;
+          border-radius: 9999px;
+          font-size: 11px;
+          font-weight: 600;
+          min-width: 18px;
+          height: 18px;
+          padding: 0 4px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 2px solid white;
+          box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+        ">${count}</div>
+      </div>
+    `,
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+  })
+}
+
+export default function MapView({ events, stickyTop = 0 }) {
+  const [activeEvent, setActiveEvent] = useState(null)
+  const [showNoLoc, setShowNoLoc] = useState(false)
+
+  const groups = useMemo(() => groupByCoord(events), [events])
+  const noLocEvents = useMemo(
+    () => events.filter(e => e.latitude == null || e.longitude == null),
+    [events]
+  )
+
+  const mapHeight = `calc(100vh - ${stickyTop + 32}px)`
+
+  return (
+    <div className="mt-4">
+      <div
+        style={{ height: mapHeight, minHeight: '400px' }}
+        className="rounded-lg overflow-hidden border border-gray-200 shadow-sm"
+      >
+        <MapContainer
+          center={MADISON_CENTER}
+          zoom={DEFAULT_ZOOM}
+          scrollWheelZoom
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <MarkerClusterGroup chunkedLoading>
+            {groups.map(group => (
+              <Marker
+                key={group.key}
+                position={[group.lat, group.lng]}
+                icon={makeBadgeIcon(group.events.length)}
+              >
+                <Popup>
+                  <PinPopup group={group} onPick={setActiveEvent} />
+                </Popup>
+              </Marker>
+            ))}
+          </MarkerClusterGroup>
+        </MapContainer>
+      </div>
+
+      {noLocEvents.length > 0 && (
+        <div className="mt-3 bg-amber-50 border border-amber-200 rounded px-3 py-2 text-sm text-amber-900">
+          <button onClick={() => setShowNoLoc(v => !v)} className="font-medium cursor-pointer">
+            {noLocEvents.length} event{noLocEvents.length === 1 ? '' : 's'} without a location {showNoLoc ? '▲' : '▼'}
+          </button>
+          {showNoLoc && (
+            <ul className="mt-2 space-y-1">
+              {noLocEvents.map(e => (
+                <li key={e.id}>
+                  <button
+                    className="text-left hover:underline cursor-pointer"
+                    onClick={() => setActiveEvent(e)}
+                  >
+                    {e.all_day ? 'All day' : formatTimeRange(e.start_at, e.end_at)} — {e.title}
+                    {e.venue_name ? <span className="text-amber-700"> · {e.venue_name}</span> : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {activeEvent && <EventModal event={activeEvent} onClose={() => setActiveEvent(null)} />}
+    </div>
+  )
+}
+
+function PinPopup({ group, onPick }) {
+  if (group.events.length === 1) {
+    const e = group.events[0]
+    return (
+      <div style={{ minWidth: '200px' }}>
+        <div style={{ fontSize: '11px', color: '#9ca3af', marginBottom: '2px' }}>
+          {e.all_day ? 'All day' : formatTimeRange(e.start_at, e.end_at)}
+        </div>
+        <div style={{ fontSize: '14px', fontWeight: 600, color: '#111827', lineHeight: '1.3' }}>
+          {e.title}
+        </div>
+        {e.venue_name && (
+          <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px' }}>{e.venue_name}</div>
+        )}
+        <button
+          onClick={() => onPick(e)}
+          style={{
+            marginTop: '8px',
+            padding: '4px 10px',
+            background: '#2563eb',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '12px',
+            cursor: 'pointer',
+          }}
+        >
+          View details
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ minWidth: '220px', maxWidth: '280px' }}>
+      <div style={{ fontSize: '12px', fontWeight: 600, color: '#374151', marginBottom: '6px' }}>
+        {group.events.length} events here
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, maxHeight: '240px', overflowY: 'auto' }}>
+        {group.events.map(e => (
+          <li key={e.id} style={{ marginBottom: '4px' }}>
+            <button
+              onClick={() => onPick(e)}
+              style={{
+                width: '100%',
+                textAlign: 'left',
+                padding: '4px 6px',
+                background: 'transparent',
+                border: '1px solid transparent',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '12px',
+                lineHeight: '1.3',
+              }}
+              onMouseEnter={ev => { ev.currentTarget.style.background = '#f3f4f6' }}
+              onMouseLeave={ev => { ev.currentTarget.style.background = 'transparent' }}
+            >
+              <span style={{ color: '#9ca3af' }}>
+                {e.all_day ? 'All day' : formatTimeRange(e.start_at, e.end_at)}
+              </span>
+              <span style={{ color: '#111827', marginLeft: '6px', fontWeight: 500 }}>{e.title}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import 'leaflet/dist/leaflet.css'
+import 'leaflet.markercluster/dist/MarkerCluster.css'
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import './index.css'
 import App from './App.jsx'
 


### PR DESCRIPTION
## Summary
- Adds a List/Map segmented toggle in the header. Map mode renders a Leaflet map of Madison with one pin per event, clustered at low zoom. Single-event pins open a popup with time/title/venue and a "View details" button → existing event modal; multi-event pins (e.g. Memorial Union on a busy day) show a list of `time — title` rows that each open the modal for that event.
- Backend: new `latitude`/`longitude` on `Event`, new `venue_geocodes` cache table, `app/geocoding.py` (Nominatim w/ 1 req/sec throttle, User-Agent, Madison bbox bias), and `app/geocode_runner.py` invoked after each scraper inside `POST /admin/scrape`. Also exposed standalone as `POST /admin/geocode` (`?force=true` clears non-success cache and retries).
- Frontend: new `leaflet`/`react-leaflet`/`react-leaflet-cluster` deps. New `MapView.jsx` (grouped pins, count badges, OSM attribution, "events without a location" panel for events whose names didn't resolve). New `EventModal.jsx` extracts the modal portal previously duplicated in `EventCard.jsx` and `AllDayStrip.jsx` so MapView can reuse it.
- Docs: `EVENT_SOURCES.md` gains a Geocoding section recording the Nominatim dependency, ToS obligations, and the OSM tile provider.

Closes #10.

## Test plan
- [x] `ruff check backend/` passes
- [x] `npm run build` succeeds (425 KB / 130 KB gzipped)
- [x] First geocode backfill: 351 events updated in 4m39s, 0 errors. ~63% of active events now have coordinates (389 / 620); the rest are venue-name-only Isthmus events that didn't resolve and appear in the no-location panel.
- [x] `GET /events?date=…` returns `latitude`/`longitude` on geocoded events; existing fields unchanged.
- [x] List view unchanged. Map toggle persists across reload.
- [x] Pin popups: single-event "View details" opens modal; multi-event list opens correct modal per row.
- [x] Re-running `POST /admin/geocode` is near-instant when cache is warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)