### PR TITLE
Rename Yesterday/Tomorrow nav buttons to Previous/Next (closes #28)

### DIFF
--- a/frontend/src/components/DatePicker.jsx
+++ b/frontend/src/components/DatePicker.jsx
@@ -12,7 +12,7 @@ export default function DatePicker({ value, onChange }) {
         onClick={() => shift(-1)}
         className="px-2 py-1 text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
       >
-        ← <span className="hidden sm:inline">Yesterday</span>
+        ← <span className="hidden sm:inline">Previous</span>
       </button>
       <input
         id="date-input"
@@ -26,7 +26,7 @@ export default function DatePicker({ value, onChange }) {
         onClick={() => shift(1)}
         className="px-2 py-1 text-sm text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded transition-colors"
       >
-        <span className="hidden sm:inline">Tomorrow</span> →
+        <span className="hidden sm:inline">Next</span> →
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Renames the date navigation button labels in `DatePicker.jsx` from "Yesterday" / "Tomorrow" to "Previous" / "Next"
- Arrows and responsive hide/show behavior are unchanged

## Test plan
- [ ] Open the app and confirm header buttons read "← Previous" and "Next →" at desktop width
- [ ] Confirm buttons still navigate one day back/forward
- [ ] Confirm only arrows appear at narrow (mobile) width

🤖 Generated with [Claude Code](https://claude.com/claude-code)