### PR TITLE
Add ADMIN_API_KEY auth to /admin/* endpoints (closes #31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,9 +127,21 @@ After each scraper runs inside `POST /admin/scrape`, a geocoding pass populates 
 
 Scrapers don't need to do anything special — populating `RawEvent.venue_address` (preferred) or `RawEvent.venue_name` is enough for the geocoder to attempt a lookup.
 
+### Tagging (`backend/app/tagger.py`)
+
+`tag_untagged_events(db, model=None)` runs the LLM category-tagging pass. It selects active events whose `categories` array is empty (i.e., the source didn't pre-tag them) and whose `description` is at least 80 characters, batches them 25 at a time, and asks Claude to assign zero or more tags from `CATEGORIES`. The system prompt is sent with `cache_control: ephemeral` so repeated batches reuse the prompt cache. Predictions outside the taxonomy are silently dropped. Each batch commits independently, so a mid-run failure leaves prior batches persisted.
+
+- Runs automatically at the end of `POST /admin/scrape` after all scrapers + geocoding finish (under the `_tagging` key in the response).
+- Also exposed as `POST /admin/tag?model=<model-id>` for one-off runs or model evaluation. Without `model`, uses `settings.tagger_model` (default `claude-haiku-4-5`).
+- Idempotent — events that already have at least one category are skipped, so re-running is cheap.
+- Requires `ANTHROPIC_API_KEY` in `backend/.env`; raises `ValueError` if unset.
+- Skips events with short descriptions (<80 chars). Their card just shows no categories rather than wasting a token budget on guesses; if a source improves its descriptions, the next run picks them up.
+
 ### Environment Variables
 
 Loaded from `backend/.env` (gitignored). See `backend/.env.example` for required keys. Never hardcode credentials.
+
+`ADMIN_API_KEY` gates the `/admin/scrape`, `/admin/tag`, and `/admin/geocode` endpoints. All three require an `X-Admin-Key: <key>` request header. In development (`ENVIRONMENT=development`) with no key set the check is bypassed so existing dev workflows keep working. In production the app refuses to start if `ADMIN_API_KEY` is unset.
 
 `CORS_ORIGINS` must be a **comma-separated string**, not a JSON array. pydantic-settings v2 tries to JSON-parse `list[str]` fields from dotenv sources before validators run, which causes a `SettingsError` for non-JSON values. To avoid this, `cors_origins` is typed as `str` in `Settings` and exposed as a list via `settings.get_cors_origins()`. Do not change it back to `list[str]`.
 
@@ -179,10 +191,12 @@ To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost
 
 ## Current Build Status
 
-- **Done (Step 1):** repo skeleton, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class
-- **Done (Step 2):** multi-source `Event`/`EventSource` data model, `ingest.py`, `POST /admin/scrape` endpoint, React/Vite/Tailwind frontend (date picker + event cards)
-- **In progress (Step 3):** Isthmus integrated (iCal + RSS, 30-day window, ~235 events) and Visit Madison integrated (Simpleview JSON API, 30-day window, ~460 events with category pre-tagging); APScheduler for daily runs still planned; more sources in `docs/EVENT_SOURCES.md`
-- **In progress (Step 4):** category filter UI in frontend (multi-select tag cloud, default excludes Volunteer & Causes / Civic & Politics / Community & Clubs, persists to localStorage); LLM-assisted category tagging pass still planned (tracked in GH issue #6)
+- **Done (Step 1):** repo skeleton, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class.
+- **Done (Step 2):** multi-source `Event`/`EventSource` data model, `ingest.py`, `POST /admin/scrape` endpoint, React/Vite/Tailwind frontend (date picker + event cards).
+- **Done (Step 4):** closed category taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source's own taxonomy; LLM-assisted tagging pass shipped in `backend/app/tagger.py` (runs at end of `/admin/scrape`, also exposed as `/admin/tag`); category filter UI in frontend (multi-select tag cloud, sensible defaults, persists to localStorage).
+- **Done (Step 5):** geocoding pipeline (Nominatim, cached per venue in `venue_geocodes`) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve.
+- **Done (recent polish):** fuzzy cross-source dedup in ingest (title similarity ≥ 0.65 anchored by time + venue); explicit source priority ranking (`SOURCE_PRIORITY` in `frontend/src/lib/sources.js`); Isthmus description enrichment from event detail pages; Previous/Next nav buttons; sticky-header layout fixes.
+- **In progress (Step 3):** Isthmus integrated (iCal + RSS, 30-day window, ~235 events) and Visit Madison integrated (Simpleview JSON API, 30-day window, ~460 events); more sources in `docs/EVENT_SOURCES.md`; daily scheduling not yet wired up (no APScheduler — recommend running `/admin/scrape` from cron / systemd timer / external scheduler).
 
 Backend: http://localhost:8000 — API docs: http://localhost:8000/docs
 Frontend: http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ npm run dev
 ### 5. Seed initial events
 
 ```
-curl -X POST http://localhost:8000/admin/scrape
+curl -X POST http://localhost:8000/admin/scrape -H "X-Admin-Key: <your-key>"
 ```
 
-This runs all registered scrapers and populates the database. APScheduler (daily automation) is planned for Step 3.
+This runs all registered scrapers, geocodes any new venues, and (if `ANTHROPIC_API_KEY` is set) runs the LLM tagger on events without categories. Daily automation is not yet wired up in-process — run this from cron, a systemd timer, or any external scheduler. In development without `ADMIN_API_KEY` set the header is not required.
 
 ## Project Structure
 
@@ -71,29 +71,44 @@ This runs all registered scrapers and populates the database. APScheduler (daily
 whats-up-madison/
 ├── backend/
 │   ├── app/
-│   │   ├── main.py             # FastAPI app entry point + /admin/scrape, /admin/geocode
+│   │   ├── main.py             # FastAPI app entry point + /admin/scrape, /admin/tag, /admin/geocode
+│   │   ├── config.py           # pydantic-settings; reads backend/.env
+│   │   ├── database.py         # SQLAlchemy engine + session factory
 │   │   ├── models.py           # SQLAlchemy models (Event, EventSource, Source, VenueGeocode)
 │   │   ├── schemas.py          # Pydantic response schemas
-│   │   ├── ingest.py           # Shared scraper ingestion utility
+│   │   ├── ingest.py           # Shared scraper ingestion utility (dedup, fuzzy match, multi-source)
 │   │   ├── geocoding.py        # Nominatim wrapper (throttle, User-Agent, Madison bbox, cache)
 │   │   ├── geocode_runner.py   # Per-source and backfill geocoding passes
+│   │   ├── categories.py       # Closed category taxonomy + descriptions
+│   │   ├── tagger.py           # LLM-assisted category tagging (Anthropic SDK, prompt-cached)
 │   │   ├── routers/
 │   │   │   └── events.py       # GET /events?date=YYYY-MM-DD
 │   │   └── scrapers/
 │   │       ├── base.py         # RawEvent dataclass + BaseSource interface
-│   │       ├── isthmus.py
+│   │       ├── isthmus.py      # Isthmus iCal + RSS
+│   │       ├── visit_madison.py # Visit Madison Simpleview API
 │   │       └── ...             # one module per source
+│   ├── eval_tagger.py          # CLI for comparing tagger model cost / quality
 │   ├── Dockerfile
 │   └── requirements.txt
 ├── frontend/                   # React / Vite + Tailwind CSS
 │   └── src/
 │       ├── App.jsx             # date picker, filters, List/Map toggle
-│       └── components/
-│           ├── DatePicker.jsx
-│           ├── EventCard.jsx
-│           ├── AllDayStrip.jsx
-│           ├── EventModal.jsx  # shared expanded-detail modal (used by both card types and MapView)
-│           └── MapView.jsx     # Leaflet map of events with clustered + multi-event pins
+│       ├── components/
+│       │   ├── DatePicker.jsx
+│       │   ├── DensityRail.jsx     # sticky hourly-density bar with jump-to-hour
+│       │   ├── BucketSection.jsx   # morning/afternoon/evening/night sections
+│       │   ├── CategoryFilter.jsx
+│       │   ├── VenueFilter.jsx
+│       │   ├── EventCard.jsx
+│       │   ├── AllDayStrip.jsx
+│       │   ├── EventModal.jsx  # shared expanded-detail modal (used by both card types and MapView)
+│       │   └── MapView.jsx     # Leaflet map of events with clustered + multi-event pins
+│       └── lib/
+│           ├── categories.js   # frontend mirror of taxonomy + filter persistence
+│           ├── sources.js      # source priority ranking
+│           ├── eventTime.js    # time formatting + bucketing
+│           └── calendarUtils.js # iCal generation, Google Calendar URLs, share helpers
 ├── docker-compose.yml
 └── local_management/           # gitignored — machine-local notes and commands
 ```
@@ -102,9 +117,10 @@ whats-up-madison/
 
 - **Step 1 — Skeleton** ✅ Repo structure, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class
 - **Step 2 — First scraper + frontend** ✅ Multi-source data model (`Event`/`EventSource`), ingestion utility, React/Vite/Tailwind frontend with date picker and event cards
-- **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); Eventbrite API, City of Madison, individual venue HTML scrapers, APScheduler for daily runs still planned
-- **Step 4 — Categories** 🔄 Closed taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source taxonomy; frontend filter UI shipped (multi-select tag cloud, sensible defaults, localStorage); LLM-assisted tagging pass still planned to fill in Isthmus + future sources
+- **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); Eventbrite API, City of Madison, and individual venue HTML scrapers still planned. Daily automation runs out-of-process for now (cron / systemd timer hitting `/admin/scrape`); no in-process scheduler.
+- **Step 4 — Categories** ✅ Closed taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source taxonomy; LLM-assisted tagging pass shipped in `backend/app/tagger.py` (runs at the end of `/admin/scrape` and via the standalone `/admin/tag` endpoint, with the system prompt cached); frontend filter UI shipped (multi-select tag cloud, sensible defaults, localStorage)
 - **Step 5 — Map view** ✅ Geocoding pipeline (Nominatim, cached per venue in `venue_geocodes` so re-scrapes are free) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve
+- **Recent polish** ✅ Fuzzy cross-source dedup in ingest (title similarity ≥ 0.65 anchored by time + venue); explicit source priority ranking; Isthmus description enrichment from event detail pages; Previous/Next nav buttons; sticky-header layout fixes
 
 ## Adding a Scraper
 
@@ -151,9 +167,21 @@ Returns active events for a given date. Long-running events appear on every date
 
 `latitude` and `longitude` are populated by the geocoder when a Nominatim lookup for the venue succeeds; they are `null` for events whose venue couldn't be resolved (those events still appear in the list view and in a "without a location" panel under the map).
 
+### Admin endpoint authentication
+
+All `/admin/*` endpoints require an `X-Admin-Key` header matching `ADMIN_API_KEY` from `backend/.env`. In development mode without `ADMIN_API_KEY` set the check is bypassed; in production `ADMIN_API_KEY` must be set or the app refuses to start.
+
+```
+curl -X POST http://localhost:8000/admin/scrape -H "X-Admin-Key: <your-key>"
+```
+
 ### `POST /admin/scrape`
 
-Triggers all registered scrapers and ingests results. After each scraper, also runs a geocoding pass for any newly-active events from that source that don't yet have coordinates. Returns per-source stats including ingestion (`inserted`, `updated`, `deactivated`) and geocoding (`geocoded`, `geocode_misses`, `geocode_skipped`).
+Triggers all registered scrapers and ingests results. After each scraper, runs a geocoding pass for any newly-active events from that source that don't yet have coordinates. Once all scrapers + geocoding finish, runs the LLM tagger (if `ANTHROPIC_API_KEY` is set) to assign categories to events without any. Returns per-source stats including ingestion (`inserted`, `updated`, `deactivated`) and geocoding (`geocoded`, `geocode_misses`, `geocode_skipped`), plus a top-level `_tagging` entry with `{tagged, skipped_no_description, candidates, batches}`.
+
+### `POST /admin/tag`
+
+Run the LLM category tagger as a standalone pass. Tags only active events whose `categories` array is empty and whose description is at least 80 characters. Idempotent — already-tagged events are skipped. Optional `model=<model-id>` overrides `TAGGER_MODEL`; useful for evaluating a different Claude model without changing config. Requires `ANTHROPIC_API_KEY` in `backend/.env`.
 
 ### `POST /admin/geocode`
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,4 @@ ENVIRONMENT=development
 CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 ANTHROPIC_API_KEY=your-key-here
 TAGGER_MODEL=claude-haiku-4-5
+ADMIN_API_KEY=your-admin-key-here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -7,6 +8,13 @@ class Settings(BaseSettings):
     cors_origins: str = "http://localhost:5173,http://localhost:3000"
     anthropic_api_key: str = ""
     tagger_model: str = "claude-haiku-4-5"
+    admin_api_key: str = ""
+
+    @model_validator(mode="after")
+    def check_production_admin_key(self):
+        if self.environment == "production" and not self.admin_api_key:
+            raise ValueError("ADMIN_API_KEY must be set in production")
+        return self
 
     def get_cors_origins(self) -> list[str]:
         return [o.strip() for o in self.cors_origins.split(",")]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,9 @@
 import logging
 import logging.config
 
-from fastapi import Depends, FastAPI
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
@@ -49,12 +51,19 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.get_cors_origins(),
     allow_methods=["GET", "POST"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type", "X-Admin-Key"],
 )
 
 app.include_router(events.router)
 
 SCRAPERS = [IsthmusSource(), VisitMadisonSource()]
+
+
+def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):
+    if settings.environment == "development" and not settings.admin_api_key:
+        return
+    if not x_admin_key or x_admin_key != settings.admin_api_key:
+        raise HTTPException(status_code=401, detail="Invalid or missing X-Admin-Key")
 
 
 @app.get("/health")
@@ -63,7 +72,7 @@ def health():
 
 
 @app.post("/admin/scrape")
-def trigger_scrape(db: Session = Depends(get_db)):
+def trigger_scrape(_: None = Depends(require_admin_key), db: Session = Depends(get_db)):
     results = {}
     for scraper in SCRAPERS:
         logger.info("Starting scrape: %s", scraper.name)
@@ -91,7 +100,7 @@ def trigger_scrape(db: Session = Depends(get_db)):
 
 
 @app.post("/admin/tag")
-def trigger_tag(model: str = None, db: Session = Depends(get_db)):
+def trigger_tag(model: str = None, _: None = Depends(require_admin_key), db: Session = Depends(get_db)):
     try:
         return tag_untagged_events(db, model=model)
     except Exception as e:
@@ -99,7 +108,7 @@ def trigger_tag(model: str = None, db: Session = Depends(get_db)):
 
 
 @app.post("/admin/geocode")
-def trigger_geocode(force: bool = False, db: Session = Depends(get_db)):
+def trigger_geocode(force: bool = False, _: None = Depends(require_admin_key), db: Session = Depends(get_db)):
     try:
         return geocode_all_missing(db, force=force)
     except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `ADMIN_API_KEY` env var (via `config.py`) and a `require_admin_key` FastAPI dependency that checks the `X-Admin-Key` request header on all three admin endpoints (`/admin/scrape`, `/admin/tag`, `/admin/geocode`)
- In development mode with no key configured, the check is bypassed so existing dev workflows keep working unmodified
- In production (`ENVIRONMENT=production`), the app refuses to start if `ADMIN_API_KEY` is unset (enforced via pydantic `model_validator`)
- Narrows CORS `allow_headers` from `["*"]` to `["Content-Type", "X-Admin-Key"]`
- Documents the requirement in `AGENTS.md`, `README.md`, and `.env.example`

Also includes pre-existing doc updates to `AGENTS.md` and `README.md` that were staged but not yet committed (Steps 4/5 marked done, recent polish entries, tagger and geocoder sections).

## Test plan

- [ ] `curl -X POST http://localhost:8000/admin/geocode` → 401 (key is set in dev .env)
- [ ] Same with `-H 'X-Admin-Key: wrongkey'` → 401
- [ ] Same with `-H 'X-Admin-Key: testkey'` → 200
- [ ] Same checks pass for `/admin/tag` and `/admin/scrape`
- [ ] Remove `ADMIN_API_KEY` from `.env`, restart → dev bypass works (200 with no header)
- [ ] Set `ENVIRONMENT=production` without `ADMIN_API_KEY` → app refuses to start with a clear `ValueError`
- [ ] `ruff check backend/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)