### PR TITLE
Make date required on GET /events, drop unbounded fallback (closes #32)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Optional
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import func
@@ -14,17 +13,17 @@ router = APIRouter(prefix="/events", tags=["events"])
 
 @router.get("", response_model=list[EventResponse])
 def get_events(
-    date: Optional[datetime.date] = None,
+    date: datetime.date,
     db: Session = Depends(get_db),
 ):
-    query = (
+    return (
         db.query(Event)
         .options(joinedload(Event.sources))
-        .filter(Event.status == "active")
-    )
-    if date:
-        query = query.filter(
+        .filter(
+            Event.status == "active",
             func.date(func.timezone("America/Chicago", Event.start_at)) <= date,
             func.date(func.timezone("America/Chicago", func.coalesce(Event.end_at, Event.start_at))) >= date,
         )
-    return query.order_by(Event.start_at).all()
+        .order_by(Event.start_at)
+        .all()
+    )


### PR DESCRIPTION
## Summary

- `date` is now a required query param on `GET /events`; omitting it returns 422 instead of silently dumping all active events
- Removes the `if date:` guard — the filter is now unconditional
- Drops the unused `Optional` import

## Test plan

- [x] `curl http://localhost:8000/events` → 422 Unprocessable Entity
- [x] `curl "http://localhost:8000/events?date=2026-05-03"` → 200, normal event list
- [x] `ruff check backend/` — no lint errors
- [ ] Confirm frontend date picker is unaffected (frontend always passes `date`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)