### PR TITLE
Extract EventActionButtons to dedupe calendar/share UI (closes #33)

### DIFF
--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,8 +1,7 @@
-import { useState, useRef, useEffect } from 'react'
-import { CalendarDays, Send, Check } from 'lucide-react'
-import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
+import { useState } from 'react'
 import { sortedSources } from '../lib/sources'
 import EventModal from './EventModal'
+import EventActionButtons from './EventActionButtons'
 
 export default function AllDayStrip({ events }) {
   if (!events || events.length === 0) return null
@@ -26,50 +25,8 @@ export default function AllDayStrip({ events }) {
 
 function AllDayCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
-  const [calOpen, setCalOpen] = useState(false)
-  const [sendOpen, setSendOpen] = useState(false)
-  const [showCheck, setShowCheck] = useState(false)
-  const calRef = useRef(null)
-  const sendRef = useRef(null)
   const sources = sortedSources(event.sources)
   const primary = sources[0]
-
-  useEffect(() => {
-    if (!calOpen) return
-    function handleOutside(e) {
-      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [calOpen])
-
-  useEffect(() => {
-    if (!sendOpen) return
-    function handleOutside(e) {
-      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [sendOpen])
-
-  function flashCheck() {
-    setShowCheck(true)
-    setTimeout(() => setShowCheck(false), 1500)
-  }
-
-  async function handleCopyText(e) {
-    e.stopPropagation()
-    await navigator.clipboard.writeText(formatEventText(event))
-    setSendOpen(false)
-    flashCheck()
-  }
-
-  async function handleSendInvite(e) {
-    e.stopPropagation()
-    const result = await shareCalendarInvite(event)
-    setSendOpen(false)
-    if (result?.downloaded) flashCheck()
-  }
 
   return (
     <>
@@ -92,56 +49,7 @@ function AllDayCard({ event }) {
             <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 flex-1 min-w-0">{event.title}</h3>
           )}
           <div className="flex items-center gap-0.5 flex-shrink-0 ml-1">
-            <div className="relative" ref={calRef}>
-              <button
-                className="text-gray-400 hover:text-gray-600 p-0.5 rounded cursor-pointer"
-                onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-                title="Add to calendar"
-              >
-                <CalendarDays size={13} />
-              </button>
-              {calOpen && (
-                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                  >
-                    Google Calendar
-                  </button>
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                  >
-                    Apple / Outlook (.ics)
-                  </button>
-                </div>
-              )}
-            </div>
-            <div className="relative" ref={sendRef}>
-              <button
-                className={`p-0.5 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-                onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-                title="Send / share event"
-              >
-                {showCheck ? <Check size={13} /> : <Send size={13} />}
-              </button>
-              {sendOpen && (
-                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={handleCopyText}
-                  >
-                    Copy text
-                  </button>
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={handleSendInvite}
-                  >
-                    Calendar invite
-                  </button>
-                </div>
-              )}
-            </div>
+            <EventActionButtons event={event} compact />
           </div>
         </div>
         {event.venue_name && (

--- a/frontend/src/components/EventActionButtons.jsx
+++ b/frontend/src/components/EventActionButtons.jsx
@@ -1,0 +1,105 @@
+import { useState, useRef, useEffect } from 'react'
+import { CalendarDays, Send, Check } from 'lucide-react'
+import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
+
+export default function EventActionButtons({ event, compact = false }) {
+  const [calOpen, setCalOpen] = useState(false)
+  const [sendOpen, setSendOpen] = useState(false)
+  const [showCheck, setShowCheck] = useState(false)
+  const calRef = useRef(null)
+  const sendRef = useRef(null)
+  const iconSize = compact ? 13 : 14
+  const btnPad = compact ? 'p-0.5' : 'p-1'
+
+  useEffect(() => {
+    if (!calOpen) return
+    function handleOutside(e) {
+      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [calOpen])
+
+  useEffect(() => {
+    if (!sendOpen) return
+    function handleOutside(e) {
+      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
+    }
+    document.addEventListener('mousedown', handleOutside)
+    return () => document.removeEventListener('mousedown', handleOutside)
+  }, [sendOpen])
+
+  function flashCheck() {
+    setShowCheck(true)
+    setTimeout(() => setShowCheck(false), 1500)
+  }
+
+  async function handleCopyText(e) {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(formatEventText(event))
+    setSendOpen(false)
+    flashCheck()
+  }
+
+  async function handleSendInvite(e) {
+    e.stopPropagation()
+    const result = await shareCalendarInvite(event)
+    setSendOpen(false)
+    if (result?.downloaded) flashCheck()
+  }
+
+  return (
+    <>
+      <div className="relative" ref={calRef}>
+        <button
+          className={`text-gray-400 hover:text-gray-600 ${btnPad} rounded cursor-pointer`}
+          onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
+          title="Add to calendar"
+        >
+          <CalendarDays size={iconSize} />
+        </button>
+        {calOpen && (
+          <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+            <button
+              className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+              onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
+            >
+              Google Calendar
+            </button>
+            <button
+              className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+              onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
+            >
+              Apple / Outlook (.ics)
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="relative" ref={sendRef}>
+        <button
+          className={`${btnPad} rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
+          onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
+          title="Send / share event"
+        >
+          {showCheck ? <Check size={iconSize} /> : <Send size={iconSize} />}
+        </button>
+        {sendOpen && (
+          <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
+            <button
+              className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+              onClick={handleCopyText}
+            >
+              Copy text
+            </button>
+            <button
+              className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
+              onClick={handleSendInvite}
+            >
+              Calendar invite
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,56 +1,13 @@
-import { useState, useRef, useEffect } from 'react'
-import { CalendarDays, Send, Check } from 'lucide-react'
+import { useState } from 'react'
 import { formatTimeRange } from '../lib/eventTime'
-import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 import { sortedSources } from '../lib/sources'
 import EventModal from './EventModal'
+import EventActionButtons from './EventActionButtons'
 
 export default function EventCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
-  const [calOpen, setCalOpen] = useState(false)
-  const [sendOpen, setSendOpen] = useState(false)
-  const [showCheck, setShowCheck] = useState(false)
-  const calRef = useRef(null)
-  const sendRef = useRef(null)
   const sources = sortedSources(event.sources)
   const primaryUrl = sources[0]?.source_url
-
-  useEffect(() => {
-    if (!calOpen) return
-    function handleOutside(e) {
-      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [calOpen])
-
-  useEffect(() => {
-    if (!sendOpen) return
-    function handleOutside(e) {
-      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [sendOpen])
-
-  function flashCheck() {
-    setShowCheck(true)
-    setTimeout(() => setShowCheck(false), 1500)
-  }
-
-  async function handleCopyText(e) {
-    e.stopPropagation()
-    await navigator.clipboard.writeText(formatEventText(event))
-    setSendOpen(false)
-    flashCheck()
-  }
-
-  async function handleSendInvite(e) {
-    e.stopPropagation()
-    const result = await shareCalendarInvite(event)
-    setSendOpen(false)
-    if (result?.downloaded) flashCheck()
-  }
 
   return (
     <>
@@ -61,56 +18,7 @@ export default function EventCard({ event }) {
         <div className="flex items-start justify-between mb-0.5">
           <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
           <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
-            <div className="relative" ref={calRef}>
-              <button
-                className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
-                onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-                title="Add to calendar"
-              >
-                <CalendarDays size={14} />
-              </button>
-              {calOpen && (
-                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                  >
-                    Google Calendar
-                  </button>
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                  >
-                    Apple / Outlook (.ics)
-                  </button>
-                </div>
-              )}
-            </div>
-            <div className="relative" ref={sendRef}>
-              <button
-                className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-                onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-                title="Send / share event"
-              >
-                {showCheck ? <Check size={14} /> : <Send size={14} />}
-              </button>
-              {sendOpen && (
-                <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={handleCopyText}
-                  >
-                    Copy text
-                  </button>
-                  <button
-                    className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                    onClick={handleSendInvite}
-                  >
-                    Calendar invite
-                  </button>
-                </div>
-              )}
-            </div>
+            <EventActionButtons event={event} />
           </div>
         </div>
         {primaryUrl ? (

--- a/frontend/src/components/EventModal.jsx
+++ b/frontend/src/components/EventModal.jsx
@@ -1,36 +1,13 @@
-import { useState, useRef, useEffect } from 'react'
+import { useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import { CalendarDays, Send, Check, X } from 'lucide-react'
+import { X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
-import { googleCalendarUrl, downloadIcal, shareCalendarInvite, formatEventText } from '../lib/calendarUtils'
 import { sortedSources } from '../lib/sources'
+import EventActionButtons from './EventActionButtons'
 
 export default function EventModal({ event, onClose }) {
-  const [calOpen, setCalOpen] = useState(false)
-  const [sendOpen, setSendOpen] = useState(false)
-  const [showCheck, setShowCheck] = useState(false)
-  const calRef = useRef(null)
-  const sendRef = useRef(null)
   const sources = sortedSources(event.sources)
   const primaryUrl = sources[0]?.source_url
-
-  useEffect(() => {
-    if (!calOpen) return
-    function handleOutside(e) {
-      if (calRef.current && !calRef.current.contains(e.target)) setCalOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [calOpen])
-
-  useEffect(() => {
-    if (!sendOpen) return
-    function handleOutside(e) {
-      if (sendRef.current && !sendRef.current.contains(e.target)) setSendOpen(false)
-    }
-    document.addEventListener('mousedown', handleOutside)
-    return () => document.removeEventListener('mousedown', handleOutside)
-  }, [sendOpen])
 
   useEffect(() => {
     function handleKey(e) {
@@ -39,25 +16,6 @@ export default function EventModal({ event, onClose }) {
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
-
-  function flashCheck() {
-    setShowCheck(true)
-    setTimeout(() => setShowCheck(false), 1500)
-  }
-
-  async function handleCopyText(e) {
-    e.stopPropagation()
-    await navigator.clipboard.writeText(formatEventText(event))
-    setSendOpen(false)
-    flashCheck()
-  }
-
-  async function handleSendInvite(e) {
-    e.stopPropagation()
-    const result = await shareCalendarInvite(event)
-    setSendOpen(false)
-    if (result?.downloaded) flashCheck()
-  }
 
   return createPortal(
     <div
@@ -91,56 +49,7 @@ export default function EventModal({ event, onClose }) {
               <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
             )}
             <div className="flex items-center gap-0.5 flex-shrink-0">
-              <div className="relative" ref={calRef}>
-                <button
-                  className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
-                  onClick={e => { e.stopPropagation(); setCalOpen(o => !o); setSendOpen(false) }}
-                  title="Add to calendar"
-                >
-                  <CalendarDays size={14} />
-                </button>
-                {calOpen && (
-                  <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                    <button
-                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                      onClick={e => { e.stopPropagation(); window.open(googleCalendarUrl(event), '_blank'); setCalOpen(false) }}
-                    >
-                      Google Calendar
-                    </button>
-                    <button
-                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                      onClick={e => { e.stopPropagation(); downloadIcal(event); setCalOpen(false) }}
-                    >
-                      Apple / Outlook (.ics)
-                    </button>
-                  </div>
-                )}
-              </div>
-              <div className="relative" ref={sendRef}>
-                <button
-                  className={`p-1 rounded cursor-pointer ${showCheck ? 'text-green-600' : 'text-gray-400 hover:text-gray-600'}`}
-                  onClick={e => { e.stopPropagation(); setSendOpen(o => !o); setCalOpen(false) }}
-                  title="Send / share event"
-                >
-                  {showCheck ? <Check size={14} /> : <Send size={14} />}
-                </button>
-                {sendOpen && (
-                  <div className="absolute right-0 top-6 z-10 bg-white border border-gray-200 rounded shadow-md text-sm min-w-max">
-                    <button
-                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                      onClick={handleCopyText}
-                    >
-                      Copy text
-                    </button>
-                    <button
-                      className="block w-full text-left px-3 py-2 hover:bg-gray-50 whitespace-nowrap"
-                      onClick={handleSendInvite}
-                    >
-                      Calendar invite
-                    </button>
-                  </div>
-                )}
-              </div>
+              <EventActionButtons event={event} />
               <button
                 className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"
                 onClick={onClose}


### PR DESCRIPTION
## Summary

- Extracts the duplicated calendar-add and send/share button UI into a new `EventActionButtons` component, consumed by `EventCard`, `AllDayCard`, and `EventModal`
- All shared state (`calOpen`, `sendOpen`, `showCheck`), refs, click-outside handlers, and async action functions live in one place — bug fixes to this UI now only need to happen once
- A `compact` prop (default `false`) handles `AllDayCard`'s smaller icon/padding variant (`size=13`, `p-0.5` vs `size=14`, `p-1`)
- `EventModal` retains its own Escape-key handler (that's modal-scoped behavior, not part of the action buttons)

## Test plan

- [ ] Exercise calendar dropdown from an `EventCard`: Google Calendar opens, .ics downloads
- [ ] Exercise send dropdown from an `EventCard`: Copy text, Calendar invite
- [ ] Same four actions from an `AllDayCard` — confirm compact sizing looks correct
- [ ] Same four actions from `EventModal` opened via `EventCard` click
- [ ] Same four actions from `EventModal` opened via `AllDayCard` click
- [ ] Same four actions from `EventModal` opened via MapView pin popup
- [ ] Escape closes the modal (EventModal's own handler, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)