### PR TITLE
Production Docker hardening (closes #34)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_DB=whatsup
+POSTGRES_USER=whatsup
+POSTGRES_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ npm run dev
 
 - Frontend: http://localhost:5173
 
+### Production deployment
+
+Copy the root `.env.example` to `.env` and set real credentials:
+
+```
+cp .env.example .env
+```
+
+Then start with the prod overlay — this drops `--reload`, externalizes DB credentials, and runs as a non-root user:
+
+```
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+You'll also need `backend/.env` with `ANTHROPIC_API_KEY`, `ADMIN_API_KEY`, `CORS_ORIGINS`, etc. (see `backend/.env.example`).
+
 ### 5. Seed initial events
 
 ```
@@ -110,6 +126,8 @@ whats-up-madison/
 │           ├── eventTime.js    # time formatting + bucketing
 │           └── calendarUtils.js # iCal generation, Google Calendar URLs, share helpers
 ├── docker-compose.yml
+├── docker-compose.prod.yml     # prod overlay: drops --reload, externalizes creds, non-root user
+├── .env.example                # template for root-level Docker Compose env vars (prod)
 └── local_management/           # gitignored — machine-local notes and commands
 ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN useradd -m appuser && chown -R appuser /app
+USER appuser
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+
+  backend:
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      ENVIRONMENT: production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_PASSWORD: whatsup
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U whatsup"]
       interval: 5s


### PR DESCRIPTION
## Summary

- **`backend/Dockerfile`**: adds `appuser`, chowns `/app`, sets `USER appuser` — container no longer runs as root
- **`docker-compose.yml`**: removes the `5432:5432` host port binding on `db` (backend connects via the internal compose network; no host exposure needed in dev or prod)
- **`docker-compose.prod.yml`** (new): compose overlay that drops `--reload`, externalizes DB credentials via `${POSTGRES_USER}`, `${POSTGRES_PASSWORD}`, `${POSTGRES_DB}`, and sets `ENVIRONMENT=production`
- **`.env.example`** (new, root-level): template for compose-level env vars consumed by the prod overlay
- **`README.md`**: adds production deployment instructions and updates the project structure tree

### Usage

```
cp .env.example .env   # fill in real credentials
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
```

### Verification

- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` shows backend command without `--reload` and DB env vars substituted from `.env`
- `ss -ltn | grep 5432` on the host shows no listener after removing the port binding from `docker-compose.yml`
- `docker exec <container> id` shows `uid=1000(appuser)` rather than `root`

## Test plan

- [ ] Dev stack (`docker compose up`) still starts cleanly and backend reaches Postgres
- [ ] Prod stack (`docker compose -f docker-compose.yml -f docker-compose.prod.yml up`) starts without `--reload` in the uvicorn process args
- [ ] No `0.0.0.0:5432` listener on host after bringing up either compose config
- [ ] Backend container process runs as `appuser`, not `root`

🤖 Generated with [Claude Code](https://claude.com/claude-code)