### PR TITLE
Add HTTP retry/backoff to Isthmus and Visit Madison scrapers (closes #35)

### DIFF
--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -1,9 +1,15 @@
 import hashlib
 import html
+import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
+
+import httpx
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -27,6 +33,33 @@ class RawEvent:
             (self.venue_name or "").lower().strip(),
         ])
         return hashlib.sha256(key.encode()).hexdigest()
+
+
+def _is_retriable(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    return isinstance(exc, (httpx.TimeoutException, httpx.ConnectError, httpx.RemoteProtocolError))
+
+
+def _log_retry_attempt(retry_state) -> None:
+    logger.warning(
+        "HTTP request failed (attempt %d/3), retrying: %s",
+        retry_state.attempt_number,
+        retry_state.outcome.exception(),
+    )
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=8),
+    retry=retry_if_exception(_is_retriable),
+    before_sleep=_log_retry_attempt,
+)
+def http_get_with_retry(url: str, **kwargs) -> httpx.Response:
+    """GET `url` with automatic retry on 5xx and network/timeout errors."""
+    resp = httpx.get(url, **kwargs)
+    resp.raise_for_status()
+    return resp
 
 
 def clean_html_text(s: str) -> str:

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -5,12 +5,11 @@ from datetime import date, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
 
-import httpx
 import recurring_ical_events
 from bs4 import BeautifulSoup
 from icalendar import Calendar
 
-from app.scrapers.base import BaseSource, RawEvent, clean_html_text
+from app.scrapers.base import BaseSource, RawEvent, clean_html_text, http_get_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -24,8 +23,7 @@ _FETCH_DELAY = 0.5  # seconds between detail-page fetches
 
 def _fetch_full_description(url: str) -> str | None:
     try:
-        resp = httpx.get(url, timeout=15)
-        resp.raise_for_status()
+        resp = http_get_with_retry(url, timeout=15)
         soup = BeautifulSoup(resp.content, "lxml")
         content = soup.find(id="content")
         if not content:
@@ -78,8 +76,7 @@ def _build_url_map(
     title_date_map: dict[tuple[str, str], str] = {}
     page = 1
     while True:
-        resp = httpx.get(_RSS_BASE, params={"page": page}, timeout=30)
-        resp.raise_for_status()
+        resp = http_get_with_retry(_RSS_BASE, params={"page": page}, timeout=30)
         root = ET.fromstring(resp.content)
         items = root.findall(".//item")
         if not items:
@@ -123,8 +120,7 @@ def _parse_ical(
     url_map: dict[tuple[str, str, str], str],
     title_date_map: dict[tuple[str, str], str],
 ) -> list[RawEvent]:
-    resp = httpx.get(_ICAL_URL, timeout=30)
-    resp.raise_for_status()
+    resp = http_get_with_retry(_ICAL_URL, timeout=30)
     cal = Calendar.from_ical(resp.content)
 
     events = []

--- a/backend/app/scrapers/visit_madison.py
+++ b/backend/app/scrapers/visit_madison.py
@@ -4,9 +4,7 @@ import time
 from datetime import date, datetime, time as dtime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
-import httpx
-
-from app.scrapers.base import BaseSource, RawEvent, clean_html_text
+from app.scrapers.base import BaseSource, RawEvent, clean_html_text, http_get_with_retry
 
 _API_URL = "https://www.visitmadison.com/includes/rest_v2/plugins_events_events_by_date/find/"
 _EVENTS_PAGE_URL = "https://www.visitmadison.com/events/"
@@ -87,12 +85,11 @@ class VisitMadisonSource(BaseSource):
                     "sort": {"date": 1},
                 },
             }
-            resp = httpx.get(
+            resp = http_get_with_retry(
                 _API_URL,
                 params={"json": json.dumps(payload), "token": token},
                 timeout=30,
             )
-            resp.raise_for_status()
             docs = resp.json().get("docs") or []
             for doc in docs:
                 events.extend(_to_raw_events(doc))
@@ -106,12 +103,11 @@ class VisitMadisonSource(BaseSource):
 
 def _fetch_token() -> str:
     try:
-        resp = httpx.get(_EVENTS_PAGE_URL, timeout=30)
-        resp.raise_for_status()
+        resp = http_get_with_retry(_EVENTS_PAGE_URL, timeout=30)
         match = _TOKEN_RE.search(resp.text)
         if match:
             return match.group(1)
-    except httpx.HTTPError:
+    except Exception:
         pass
     return _FALLBACK_TOKEN
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ beautifulsoup4>=4.12
 lxml>=5.3
 apscheduler>=3.10
 anthropic>=0.40
+tenacity>=8.2


### PR DESCRIPTION
## Summary

- Adds `http_get_with_retry()` to `backend/app/scrapers/base.py` (tenacity-backed): 3 attempts, exponential backoff 1s–8s, retries on 5xx + connection/timeout errors, skips 4xx, logs a WARNING before each retry sleep
- Replaces all bare `httpx.get()` calls in `isthmus.py` (RSS pagination, iCal fetch, detail-page enrichment) and `visit_madison.py` (token scrape, paginated API calls)
- Adds `tenacity>=8.2` to `requirements.txt`

## Test plan

- [x] `ruff check backend/` — all checks passed
- [x] `POST /admin/scrape` on the rebuilt container: Isthmus (195 events) and Visit Madison (424 events) both completed successfully with no spurious retry warnings on the happy path
- [ ] To manually verify retry fires: temporarily point one fetch at an invalid host and confirm WARNING logs appear before each attempt, then the scrape fails gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)