### PR TITLE
Persist hiddenVenues filter to localStorage and fix AllDayStrip sticky offset

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,8 @@ import {
   filterEvents,
   loadFilterState,
   saveFilterState,
+  loadHiddenVenues,
+  saveHiddenVenues,
 } from './lib/categories'
 
 function toLocalDateString(date) {
@@ -47,7 +49,7 @@ export default function App() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [filter, setFilter] = useState(loadFilterState)
-  const [hiddenVenues, setHiddenVenues] = useState(new Set())
+  const [hiddenVenues, setHiddenVenues] = useState(loadHiddenVenues)
   const [viewMode, setViewMode] = useState(loadViewMode)
 
   const headerRef = useRef(null)
@@ -75,7 +77,6 @@ export default function App() {
   useEffect(() => {
     setLoading(true)
     setError(null)
-    setHiddenVenues(new Set())
     fetch(`/events?date=${selectedDate}`)
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -89,6 +90,10 @@ export default function App() {
   useEffect(() => {
     saveFilterState(filter)
   }, [filter])
+
+  useEffect(() => {
+    saveHiddenVenues(hiddenVenues)
+  }, [hiddenVenues])
 
   useEffect(() => {
     try { localStorage.setItem(VIEW_KEY, viewMode) } catch { /* ignore quota */ }
@@ -182,7 +187,7 @@ export default function App() {
                     hourCounts={partition.hourCounts}
                     onJumpToHour={handleJumpToHour}
                   />
-                  <AllDayStrip events={partition.allday} />
+                  <AllDayStrip events={partition.allday} stickyTop={headerH + railH} />
                   {BUCKETS.map((b) => (
                     <BucketSection
                       key={b.id}

--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -3,12 +3,12 @@ import { sortedSources } from '../lib/sources'
 import EventModal from './EventModal'
 import EventActionButtons from './EventActionButtons'
 
-export default function AllDayStrip({ events }) {
+export default function AllDayStrip({ events, stickyTop }) {
   if (!events || events.length === 0) return null
 
   return (
     <section id="allday" className="scroll-mt-32 mt-4">
-      <h2 className="sticky top-32 z-10 bg-emerald-50 border border-emerald-200 text-emerald-900 rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between">
+      <h2 className="sticky z-10 bg-emerald-50 border border-emerald-200 text-emerald-900 rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between" style={{ top: stickyTop }}>
         <span>All Day / Time Varies</span>
         <span className="text-xs font-normal opacity-70">
           {events.length} event{events.length === 1 ? '' : 's'}

--- a/frontend/src/lib/categories.js
+++ b/frontend/src/lib/categories.js
@@ -76,6 +76,25 @@ export function isDefaultFilterState({ selected, includeUncategorized }) {
   return true
 }
 
+const HIDDEN_VENUES_KEY = 'wum.hiddenVenues.v1'
+
+export function loadHiddenVenues() {
+  try {
+    const raw = localStorage.getItem(HIDDEN_VENUES_KEY)
+    if (!raw) return new Set()
+    const parsed = JSON.parse(raw)
+    return new Set(Array.isArray(parsed) ? parsed : [])
+  } catch {
+    return new Set()
+  }
+}
+
+export function saveHiddenVenues(hiddenVenues) {
+  try {
+    localStorage.setItem(HIDDEN_VENUES_KEY, JSON.stringify([...hiddenVenues].sort()))
+  } catch { /* ignore */ }
+}
+
 export function filterEvents(events, { selected, includeUncategorized }) {
   return events.filter((e) => {
     if (!e.categories || e.categories.length === 0) {


### PR DESCRIPTION
## Summary

- **hiddenVenues persistence**: adds `loadHiddenVenues` / `saveHiddenVenues` to `frontend/src/lib/categories.js` (key `wum.hiddenVenues.v1`, stored as a sorted string array, deserialized to a `Set`). `App.jsx` now initializes from localStorage, persists via effect, and no longer resets hidden venues on date change — the preference survives navigation between dates and view modes.
- **AllDayStrip sticky offset**: `AllDayStrip` now accepts a `stickyTop` prop applied as an inline style (replacing the hardcoded `top-32`). `App.jsx` passes `stickyTop={headerH + railH}`, matching the same dynamic value already used by `BucketSection`, so the two sticky headers stay in sync when the DensityRail wraps.

## Test plan

1. `cd frontend && npm run dev`, load a date with events
2. Hide one or more venues via VenueFilter — refresh the page; venues should remain hidden
3. Change the selected date — hidden venues should survive
4. Toggle List ↔ Map — hidden venues should survive
5. Resize the window until the DensityRail wraps to two lines; confirm the AllDayStrip sticky header sits flush against the bottom of the rail with no overlap
6. `npm run build` — passes with no errors ✅
7. `ruff check backend/` — passes ✅

closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)