### PR TITLE
Frontend a11y: EventModal dialog role, MapView region label, DensityRail focus ring

### DIFF
--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -31,8 +31,10 @@ function AllDayCard({ event }) {
   return (
     <>
       <div
-        className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none"
+        tabIndex={0}
+        className="bg-white rounded-md border border-gray-200 px-3 py-2 shadow-sm cursor-pointer hover:border-emerald-300 hover:shadow transition select-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1"
         onClick={() => setModalOpen(true)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalOpen(true) } }}
       >
         <div className="flex items-start justify-between gap-1">
           {primary?.source_url ? (

--- a/frontend/src/components/DensityRail.jsx
+++ b/frontend/src/components/DensityRail.jsx
@@ -32,7 +32,7 @@ const DensityRail = forwardRef(function DensityRail({ hourCounts, onJumpToHour, 
               disabled={isEmpty}
               aria-label={`${count} event${count === 1 ? '' : 's'} starting at ${formatHourLabel(h)}`}
               title={`${formatHourLabel(h)}: ${count} event${count === 1 ? '' : 's'}`}
-              className={`flex-1 relative h-full min-w-0 ${
+              className={`flex-1 relative h-full min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 focus-visible:outline-offset-1 ${
                 isEmpty ? 'cursor-default' : 'cursor-pointer group'
               }`}
             >

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -12,8 +12,10 @@ export default function EventCard({ event }) {
   return (
     <>
       <div
-        className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none"
+        tabIndex={0}
+        className="bg-white rounded-lg border border-gray-200 px-4 py-3 shadow-sm flex flex-col cursor-pointer hover:border-gray-300 hover:shadow transition select-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
         onClick={() => setModalOpen(true)}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalOpen(true) } }}
       >
         <div className="flex items-start justify-between mb-0.5">
           <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>

--- a/frontend/src/components/EventModal.jsx
+++ b/frontend/src/components/EventModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
@@ -8,6 +8,7 @@ import EventActionButtons from './EventActionButtons'
 export default function EventModal({ event, onClose }) {
   const sources = sortedSources(event.sources)
   const primaryUrl = sources[0]?.source_url
+  const dialogRef = useRef(null)
 
   useEffect(() => {
     function handleKey(e) {
@@ -17,6 +18,12 @@ export default function EventModal({ event, onClose }) {
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
+  useEffect(() => {
+    const previousFocus = document.activeElement
+    dialogRef.current?.focus()
+    return () => { previousFocus?.focus() }
+  }, [])
+
   return createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center p-4"
@@ -25,7 +32,12 @@ export default function EventModal({ event, onClose }) {
     >
       <div className="absolute inset-0 bg-black/30" />
       <div
-        className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto"
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="event-modal-title"
+        tabIndex={-1}
+        className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto focus:outline-none"
         onClick={e => e.stopPropagation()}
       >
         <div className="px-5 py-4 flex flex-col gap-2">
@@ -34,6 +46,7 @@ export default function EventModal({ event, onClose }) {
               <div className="flex-1 min-w-0">
                 {primaryUrl ? (
                   <a
+                    id="event-modal-title"
                     href={primaryUrl}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -42,7 +55,7 @@ export default function EventModal({ event, onClose }) {
                     {event.title}
                   </a>
                 ) : (
-                  <h3 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h3>
+                  <h3 id="event-modal-title" className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h3>
                 )}
               </div>
             ) : (
@@ -62,6 +75,7 @@ export default function EventModal({ event, onClose }) {
           {!event.all_day && (
             primaryUrl ? (
               <a
+                id="event-modal-title"
                 href={primaryUrl}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -70,7 +84,7 @@ export default function EventModal({ event, onClose }) {
                 {event.title}
               </a>
             ) : (
-              <h2 className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h2>
+              <h2 id="event-modal-title" className="text-lg font-semibold text-gray-900 leading-snug">{event.title}</h2>
             )
           )}
           {event.venue_name && (

--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -80,6 +80,8 @@ export default function MapView({ events, stickyTop = 0 }) {
   return (
     <div className="mt-4">
       <div
+        role="region"
+        aria-label="Map of Madison events"
         style={{ height: mapHeight, minHeight: '400px' }}
         className="rounded-lg overflow-hidden border border-gray-200 shadow-sm"
       >


### PR DESCRIPTION
## Summary

- **EventModal:** adds `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing to the event title element; focus is moved into the dialog on open and restored to the opener element on close via `useRef` + `useEffect`.
- **MapView:** wraps `MapContainer` in `role="region" aria-label="Map of Madison events"` so screen readers announce it as a named landmark.
- **DensityRail:** adds `focus-visible:outline` classes to the hour-bar buttons so keyboard users see a blue ring when navigating with Tab.

## Test plan

1. Tab through the page — confirm a blue focus ring appears on non-empty density rail bars.
2. Open an event modal from keyboard (Enter on a card) — confirm focus moves inside the modal; press Escape and confirm focus returns to the opener.
3. In DevTools Elements, open a modal and confirm the content div has `role="dialog"`, `aria-modal="true"`, `aria-labelledby="event-modal-title"`, and the title element has `id="event-modal-title"`.
4. Switch to Map view; inspect the MapContainer wrapper div and confirm `role="region"` and `aria-label="Map of Madison events"` are present.

closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)