### PR TITLE
Add isSafeHttpUrl guard for source_url hrefs (defense-in-depth)

### DIFF
--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { sortedSources } from '../lib/sources'
+import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventModal from './EventModal'
 import EventActionButtons from './EventActionButtons'
 
@@ -37,7 +37,7 @@ function AllDayCard({ event }) {
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalOpen(true) } }}
       >
         <div className="flex items-start justify-between gap-1">
-          {primary?.source_url ? (
+          {isSafeHttpUrl(primary?.source_url) ? (
             <a
               href={primary.source_url}
               target="_blank"
@@ -77,16 +77,22 @@ function AllDayCard({ event }) {
         {sources.length > 0 && (
           <div className="mt-1.5 flex flex-wrap gap-2">
             {sources.map((s) => (
-              <a
-                key={s.source_name}
-                href={s.source_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
-                onClick={e => e.stopPropagation()}
-              >
-                {s.source_name} ↗
-              </a>
+              isSafeHttpUrl(s.source_url) ? (
+                <a
+                  key={s.source_name}
+                  href={s.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline"
+                  onClick={e => e.stopPropagation()}
+                >
+                  {s.source_name} ↗
+                </a>
+              ) : (
+                <span key={s.source_name} className="text-xs text-gray-500">
+                  {s.source_name}
+                </span>
+              )
             ))}
           </div>
         )}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { formatTimeRange } from '../lib/eventTime'
-import { sortedSources } from '../lib/sources'
+import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventModal from './EventModal'
 import EventActionButtons from './EventActionButtons'
 
 export default function EventCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
   const sources = sortedSources(event.sources)
-  const primaryUrl = sources[0]?.source_url
+  const primaryUrl = isSafeHttpUrl(sources[0]?.source_url) ? sources[0].source_url : null
 
   return (
     <>
@@ -59,16 +59,22 @@ export default function EventCard({ event }) {
         {sources.length > 0 && (
           <div className="mt-auto pt-2 flex flex-wrap gap-2">
             {sources.map((s) => (
-              <a
-                key={s.source_name}
-                href={s.source_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-blue-600 hover:underline"
-                onClick={e => e.stopPropagation()}
-              >
-                {s.source_name} ↗
-              </a>
+              isSafeHttpUrl(s.source_url) ? (
+                <a
+                  key={s.source_name}
+                  href={s.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-600 hover:underline"
+                  onClick={e => e.stopPropagation()}
+                >
+                  {s.source_name} ↗
+                </a>
+              ) : (
+                <span key={s.source_name} className="text-xs text-gray-500">
+                  {s.source_name}
+                </span>
+              )
             ))}
           </div>
         )}

--- a/frontend/src/components/EventModal.jsx
+++ b/frontend/src/components/EventModal.jsx
@@ -2,12 +2,12 @@ import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
-import { sortedSources } from '../lib/sources'
+import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventActionButtons from './EventActionButtons'
 
 export default function EventModal({ event, onClose }) {
   const sources = sortedSources(event.sources)
-  const primaryUrl = sources[0]?.source_url
+  const primaryUrl = isSafeHttpUrl(sources[0]?.source_url) ? sources[0].source_url : null
   const dialogRef = useRef(null)
 
   useEffect(() => {
@@ -112,15 +112,21 @@ export default function EventModal({ event, onClose }) {
           {sources.length > 0 && (
             <div className="pt-2 flex flex-wrap gap-2 border-t border-gray-100 mt-1">
               {sources.map((s) => (
-                <a
-                  key={s.source_name}
-                  href={s.source_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-xs text-blue-600 hover:underline"
-                >
-                  {s.source_name} ↗
-                </a>
+                isSafeHttpUrl(s.source_url) ? (
+                  <a
+                    key={s.source_name}
+                    href={s.source_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-600 hover:underline"
+                  >
+                    {s.source_name} ↗
+                  </a>
+                ) : (
+                  <span key={s.source_name} className="text-xs text-gray-500">
+                    {s.source_name}
+                  </span>
+                )
               ))}
             </div>
           )}

--- a/frontend/src/lib/sources.js
+++ b/frontend/src/lib/sources.js
@@ -8,3 +8,12 @@ export function sortedSources(sources) {
     return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi)
   })
 }
+
+export function isSafeHttpUrl(url) {
+  try {
+    const u = new URL(url)
+    return u.protocol === 'http:' || u.protocol === 'https:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `isSafeHttpUrl(url)` to `frontend/src/lib/sources.js` — rejects any URL whose protocol is not `http:` or `https:` (e.g. `javascript:`, `data:`)
- Guards all six `href` render sites across `EventCard`, `AllDayCard` (AllDayStrip), and `EventModal`: both the primary title link and the per-source footer link in each component
- Unsafe URLs degrade gracefully to a plain `<span>` with the source name, preserving attribution without a clickable href

closes #38

## Verification

- [x] `npm run build` passes with no errors
- [x] `ruff check backend/` passes (no backend changes)
- [x] Lint passes
- [x] Open the frontend and confirm source links on event cards/modals still work for normal https:// URLs
- [ ] In browser DevTools, temporarily override a `source_url` to `javascript:alert(1)` on a rendered event; confirm the component renders a plain span (source name, no arrow) instead of a clickable link