### PR TITLE
Cleanup: drop apscheduler dependency and unused Source model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,6 @@
 import uuid
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -43,19 +43,6 @@ class EventSource(Base):
     event = relationship("Event", back_populates="sources")
 
     __table_args__ = (UniqueConstraint("event_id", "source_name"),)
-
-
-class Source(Base):
-    __tablename__ = "sources"
-
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    name = Column(String, nullable=False)
-    scraper_type = Column(String, nullable=False)  # api, ical, html
-    config = Column(JSONB)
-    enabled = Column(Boolean, default=True)
-    last_run_at = Column(DateTime(timezone=True))
-    last_run_status = Column(String)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
 
 
 class VenueGeocode(Base):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,5 @@ icalendar>=5.0
 recurring_ical_events>=3.0
 beautifulsoup4>=4.12
 lxml>=5.3
-apscheduler>=3.10
 anthropic>=0.40
 tenacity>=8.2


### PR DESCRIPTION
Removes two pieces of dead code identified in the May 2026 codebase review.

## Changes

- **`backend/requirements.txt`**: Drop `apscheduler>=3.10`. Was added when an in-process daily scheduler was planned; scheduling now runs out-of-process (cron/systemd hitting `/admin/scrape`). Nothing in the codebase imports it.
- **`backend/app/models.py`**: Delete the `Source` SQLAlchemy model. Was scaffolded for storing per-scraper config and run metadata, but scrapers are registered in-code (`main.py:SCRAPERS`) and nothing reads or writes the `sources` table. Also drops the now-unused `JSONB` import that `Source` alone required.

closes #39

## Verification
- [x] `grep -rn "apscheduler|class Source" backend/` — nothing remains (only `SourceRef`, a Pydantic schema, is untouched)
- [x] `ruff check backend/` — lint passes
- [x] `docker compose down -v && docker compose up -d` — stack restarts cleanly
- [x] `POST /admin/scrape` returns HTTP 200; Isthmus (195 inserted) and Visit Madison (395 inserted, 2 updated) both complete successfully with geocoding and tagging