### PR TITLE
Add backend test suite covering ingest.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 
 # Docker volumes
 postgres_data/
+
+# Git worktrees
+.worktrees/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,7 @@ beautifulsoup4>=4.12
 lxml>=5.3
 anthropic>=0.40
 tenacity>=8.2
+
+# Dev / testing
+pytest>=8.0
+testcontainers[postgres]>=4.8

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from testcontainers.postgres import PostgresContainer
+
+from app.database import Base
+
+
+@pytest.fixture(scope="session")
+def pg_container():
+    with PostgresContainer("postgres:16-alpine") as pg:
+        yield pg
+
+
+@pytest.fixture(scope="session")
+def engine(pg_container):
+    eng = create_engine(pg_container.get_connection_url())
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture(scope="session")
+def SessionFactory(engine):
+    return sessionmaker(bind=engine, autoflush=False)
+
+
+@pytest.fixture
+def db(SessionFactory, engine):
+    session = SessionFactory()
+    yield session
+    session.close()
+    with engine.connect() as conn:
+        conn.execute(text("TRUNCATE event_sources, events RESTART IDENTITY CASCADE"))
+        conn.commit()

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1,0 +1,159 @@
+from datetime import datetime, timezone
+
+from app.ingest import ingest_events
+from app.models import Event, EventSource
+from app.scrapers.base import RawEvent
+
+
+def _dt(hour: int = 19) -> datetime:
+    return datetime(2026, 6, 15, hour, 0, 0, tzinfo=timezone.utc)
+
+
+def _raw(
+    title: str = "Concert in the Park",
+    start_at: datetime | None = None,
+    source_name: str = "Source A",
+    source_url: str = "https://example.com/event/1",
+    description: str | None = None,
+    venue_name: str = "Garner Park",
+    venue_address: str | None = None,
+    categories: list[str] | None = None,
+    all_day: bool = False,
+) -> RawEvent:
+    return RawEvent(
+        title=title,
+        start_at=start_at or _dt(),
+        source_name=source_name,
+        source_url=source_url,
+        description=description,
+        venue_name=venue_name,
+        venue_address=venue_address,
+        categories=categories or [],
+        all_day=all_day,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. First-run insert
+# ---------------------------------------------------------------------------
+
+def test_first_run_insert(db):
+    stats = ingest_events("Source A", [_raw()], db)
+
+    assert stats["inserted"] == 1
+    assert stats["updated"] == 0
+
+    events = db.query(Event).all()
+    assert len(events) == 1
+    assert events[0].status == "active"
+
+    sources = db.query(EventSource).all()
+    assert len(sources) == 1
+    assert sources[0].is_active is True
+    assert sources[0].source_name == "Source A"
+
+
+# ---------------------------------------------------------------------------
+# 2. Fill-in-nulls: never overwrites set values; fills previously-null fields
+# ---------------------------------------------------------------------------
+
+def test_fill_in_nulls_does_not_overwrite(db):
+    first = _raw(description="Original description", venue_address=None)
+    ingest_events("Source A", [first], db)
+
+    second = _raw(description="New description attempt", venue_address="123 Main St")
+    stats = ingest_events("Source A", [second], db)
+
+    assert stats["updated"] == 1
+
+    event = db.query(Event).one()
+    assert event.description == "Original description"
+    assert event.venue_address == "123 Main St"
+
+
+# ---------------------------------------------------------------------------
+# 3. Two sources → one Event, two EventSource rows
+# ---------------------------------------------------------------------------
+
+def test_two_sources_one_event(db):
+    ingest_events("Source A", [_raw(source_name="Source A", source_url="https://a.example/1")], db)
+    ingest_events("Source B", [_raw(source_name="Source B", source_url="https://b.example/1")], db)
+
+    assert db.query(Event).count() == 1
+    sources = db.query(EventSource).all()
+    assert len(sources) == 2
+    names = {s.source_name for s in sources}
+    assert names == {"Source A", "Source B"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Fuzzy match: near-identical title, same time + venue → merged
+# ---------------------------------------------------------------------------
+
+def test_fuzzy_match_merges(db):
+    ingest_events("Source A", [_raw(title="Concert in the Park", source_name="Source A")], db)
+    ingest_events(
+        "Source B",
+        [_raw(title="Concert in the Parks", source_name="Source B", source_url="https://b.example/2")],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. Staleness: event removed from a run → EventSource inactive, Event removed
+# ---------------------------------------------------------------------------
+
+def test_staleness_deactivates_and_removes(db):
+    ingest_events("Source A", [_raw()], db)
+
+    stats = ingest_events("Source A", [], db)
+
+    assert stats["deactivated"] == 1
+
+    source = db.query(EventSource).one()
+    assert source.is_active is False
+
+    event = db.query(Event).one()
+    assert event.status == "removed"
+
+
+# ---------------------------------------------------------------------------
+# 6. Reactivation: removed event reappears → status back to active
+# ---------------------------------------------------------------------------
+
+def test_reactivation(db):
+    ingest_events("Source A", [_raw()], db)
+    ingest_events("Source A", [], db)
+
+    event = db.query(Event).one()
+    assert event.status == "removed"
+
+    ingest_events("Source A", [_raw()], db)
+
+    db.refresh(event)
+    assert event.status == "active"
+
+    source = db.query(EventSource).one()
+    assert source.is_active is True
+
+
+# ---------------------------------------------------------------------------
+# 7. Pre-dedup: two raws sharing a canonical_hash in one run → one Event,
+#    one EventSource, categories unioned
+# ---------------------------------------------------------------------------
+
+def test_pre_dedup_collapses_same_hash(db):
+    raw_a = _raw(title="Volunteer at Foodbank", categories=["community"])
+    raw_b = _raw(title="Volunteer at Foodbank", categories=["food"])
+
+    stats = ingest_events("Source A", [raw_a, raw_b], db)
+
+    assert stats["inserted"] == 1
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 1
+
+    event = db.query(Event).one()
+    assert set(event.categories) == {"community", "food"}


### PR DESCRIPTION
Adds a pytest suite for `backend/app/ingest.py`, which has the most non-obvious logic in the codebase (fuzzy dedup, fill-in-nulls, staleness, reactivation, category union, pre-dedup). Uses `testcontainers[postgres]` so PostgreSQL-specific types (`ARRAY(String)`) work without a live dev DB.

## What's included

- `backend/tests/conftest.py` — session-scoped `PostgresContainer` + engine fixtures; function-scoped `db` fixture with `TRUNCATE` teardown
- `backend/tests/test_ingest.py` — 7 tests:
  1. First-run insert (status=active, EventSource is_active=True)
  2. Fill-in-nulls: never overwrites set values; fills previously-null fields
  3. Two sources → one `Event`, two `EventSource` rows
  4. Fuzzy title match (same time + venue, ratio ≥ 0.65) → merged, not duplicated
  5. Staleness: event removed from run → `EventSource.is_active=False`, `Event.status=removed`
  6. Reactivation: removed event reappears → status flips back to `active`
  7. Pre-dedup: two raws sharing a `canonical_hash` in one batch → one `Event`, categories unioned
- `backend/pyproject.toml` — pytest config (`pythonpath = ["."]`, `testpaths = ["tests"]`)
- `backend/requirements.txt` — adds `pytest>=8.0` and `testcontainers[postgres]>=4.8`
- `.gitignore` — adds `.worktrees/`

## Verification

- [x] \`~/miniconda3/envs/whats-up-madison/bin/pytest backend/tests/ -v\` — 7/7 passed (12.5 s)
- [x] \`~/miniconda3/envs/whats-up-madison/bin/ruff check backend/\` — no issues

closes #40