### PR TITLE
Add GitHub Actions CI (ruff lint + pytest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check backend/
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r backend/requirements.txt
+      - run: pytest backend/tests/ -v


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` with two jobs that run on every push to `main` and every pull request.

**lint** — installs ruff, runs `ruff check backend/`

**test** — installs `backend/requirements.txt` (includes pytest + testcontainers) and runs `pytest backend/tests/ -v`. `ubuntu-latest` runners have Docker pre-installed, so testcontainers can start its Postgres container without any extra configuration.

`test` depends on `lint`, so a ruff failure short-circuits before paying the container startup cost.

## Verification

- [x] Branch contains only the intended commit
- [ ] Confirm CI runs green on this PR (will trigger on open)