### PR TITLE
Fix SAWarning: use select() instead of subquery() in not_in() filter

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime, timezone
 from difflib import SequenceMatcher
 
-from sqlalchemy import cast, func
+from sqlalchemy import cast, func, select
 from sqlalchemy import Date as SQLDate
 from sqlalchemy.orm import Session
 
@@ -118,9 +118,7 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
 
     # Mark events with no remaining active sources as removed
     active_event_ids = (
-        db.query(EventSource.event_id)
-        .filter(EventSource.is_active.is_(True))
-        .subquery()
+        select(EventSource.event_id).where(EventSource.is_active.is_(True))
     )
     db.query(Event).filter(
         Event.id.not_in(active_event_ids),


### PR DESCRIPTION
## Summary

- Replaces `.subquery()` with an explicit `select()` construct in the staleness pass inside `ingest_events()` (`backend/app/ingest.py`)
- SQLAlchemy 2.x requires a `select()` object inside `not_in()`; passing a `Subquery` triggered a `SAWarning: Coercing Subquery object into a select()` on every test run and every scrape cycle
- No behavior change — just silences the warning and aligns with SQLAlchemy 2.x idioms

## Test plan

- [ ] `pytest backend/tests/ -v` — 7/7 pass, zero warnings
- [ ] `ruff check backend/` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)