### PR TITLE
Move Base.metadata.create_all into FastAPI lifespan

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 
+from contextlib import asynccontextmanager
 from typing import Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException
@@ -43,9 +44,18 @@ logging.config.dictConfig({
 
 logger = logging.getLogger(__name__)
 
-Base.metadata.create_all(bind=engine)
 
-app = FastAPI(title="What's Up Madison")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        Base.metadata.create_all(bind=engine)
+    except Exception as e:
+        logger.exception("Schema creation failed at startup: %s", e)
+        raise
+    yield
+
+
+app = FastAPI(title="What's Up Madison", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary

- `Base.metadata.create_all(bind=engine)` previously ran at module level as a side effect of importing `app.main`. A DB failure at that point raised before FastAPI's logging was active, producing an opaque traceback instead of a structured error.
- Wrapped the call in a FastAPI `lifespan` async context manager so it runs at app startup with full logging available.
- On failure, `logger.exception` emits a structured line (`Schema creation failed at startup: ...`) before re-raising, giving operators a clear signal in the logs.

closes #42

## Verification
- [x] Ruff lint passes (`ruff check backend/`)
- [x] All 7 backend tests pass (`pytest`)
- [x] `docker compose down && docker compose up` — backend starts cleanly, `/health` returns `{"status":"ok"}`
- [x] Stopped `db` service and restarted backend — logs show structured `[ERROR] app.main: Schema creation failed at startup: ...` line before the traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)