### PR TITLE
Refactor _to_raw_events into per-strategy helpers

### DIFF
--- a/backend/app/scrapers/visit_madison.py
+++ b/backend/app/scrapers/visit_madison.py
@@ -233,6 +233,67 @@ def _map_categories(doc: dict) -> list[str]:
     return seen
 
 
+def _top_level_times(
+    doc: dict, event_date: date
+) -> tuple[datetime, datetime | None] | None:
+    """Strategy 1: top-level startTime/endTime HMS fields.
+
+    Returns (start_at, end_at) when startTime is present, None otherwise.
+    end_at is None when endTime is absent; midnight-wrap is applied when
+    end_at would otherwise fall before start_at.
+    """
+    start_t = _parse_hms(doc.get("startTime"))
+    if start_t is None:
+        return None
+    start_at = datetime.combine(event_date, start_t, tzinfo=_CENTRAL)
+    end_at = None
+    end_t = _parse_hms(doc.get("endTime"))
+    if end_t is not None:
+        end_at = datetime.combine(event_date, end_t, tzinfo=_CENTRAL)
+        if end_at < start_at:
+            end_at += timedelta(days=1)
+    return start_at, end_at
+
+
+def _day_of_week_events(
+    doc: dict, times_str: str
+) -> list[tuple[datetime, datetime]]:
+    """Strategy 3: day-of-week recurrence from the times string.
+
+    Uses startDate/endDate from the doc to resolve weekday names to actual
+    dates, then returns a list of (start_at, end_at) aware datetime pairs.
+    Returns [] when dates are missing, times_str is empty, or no days match.
+    """
+    if not times_str:
+        return []
+    start_date_raw = _parse_iso_z(doc.get("startDate"))
+    end_date_raw = _parse_iso_z(doc.get("endDate"))
+    if not start_date_raw or not end_date_raw:
+        return []
+    start_date_local = start_date_raw.astimezone(_CENTRAL).date()
+    end_date_local = end_date_raw.astimezone(_CENTRAL).date()
+    occurrences = _parse_day_occurrences(times_str, start_date_local, end_date_local)
+    result = []
+    for d, st, et in occurrences:
+        start_at = datetime.combine(d, st, tzinfo=_CENTRAL)
+        end_at = datetime.combine(d, et, tzinfo=_CENTRAL)
+        if end_at < start_at:
+            end_at += timedelta(days=1)
+        result.append((start_at, end_at))
+    return result
+
+
+def _fallback_all_day_desc(times_str: str, description: str | None) -> str | None:
+    """Strategy 4: build the description for an all-day fallback event.
+
+    Prepends times_str to description when it carries useful info (non-empty
+    and does not just say "see event description").
+    """
+    if times_str and "see event description" not in times_str.lower():
+        return f"{times_str} — {description}" if description else times_str
+    return description
+
+
 def _to_raw_events(doc: dict) -> list[RawEvent]:
     title = (doc.get("title") or "").strip()
     if not title:
@@ -242,10 +303,7 @@ def _to_raw_events(doc: dict) -> list[RawEvent]:
     if event_date is None:
         return []
 
-    start_time_hms = _parse_hms(doc.get("startTime"))
-    end_time_hms = _parse_hms(doc.get("endTime"))
     times_str = (doc.get("times") or "").strip()
-
     venue_name = (doc.get("location") or "").strip() or None
     venue_address = _build_address(doc)
     raw_desc = doc.get("description") or doc.get("teaser") or ""
@@ -269,39 +327,21 @@ def _to_raw_events(doc: dict) -> list[RawEvent]:
             source_url=source_url,
         )
 
-    if start_time_hms is not None:
-        start_at = datetime.combine(event_date, start_time_hms, tzinfo=_CENTRAL)
-        end_at = None
-        if end_time_hms is not None:
-            end_at = datetime.combine(event_date, end_time_hms, tzinfo=_CENTRAL)
-            if end_at < start_at:
-                end_at += timedelta(days=1)
-        return [make_event(start_at, end_at)]
+    # Strategy 1: top-level startTime/endTime HMS fields.
+    top = _top_level_times(doc, event_date)
+    if top is not None:
+        return [make_event(*top)]
 
-    # No top-level startTime — try structured parsing of the times field.
+    # Strategy 2: structured "From: HH:MM AM to HH:MM PM" in the times field.
     parsed = _parse_from_to_times(times_str, event_date) if times_str else None
     if parsed is not None:
         return [make_event(*parsed)]
 
-    # Try day-of-week occurrence parsing (e.g. "Friday 6:30pm-7:30pm, Saturday 11:00am-12:00pm").
-    start_date_raw = _parse_iso_z(doc.get("startDate"))
-    end_date_raw = _parse_iso_z(doc.get("endDate"))
-    if start_date_raw and end_date_raw and times_str:
-        start_date_local = start_date_raw.astimezone(_CENTRAL).date()
-        end_date_local = end_date_raw.astimezone(_CENTRAL).date()
-        occurrences = _parse_day_occurrences(times_str, start_date_local, end_date_local)
-        if occurrences:
-            result = []
-            for d, st, et in occurrences:
-                start_at = datetime.combine(d, st, tzinfo=_CENTRAL)
-                end_at = datetime.combine(d, et, tzinfo=_CENTRAL)
-                if end_at < start_at:
-                    end_at += timedelta(days=1)
-                result.append(make_event(start_at, end_at))
-            return result
+    # Strategy 3: day-of-week recurrence ("Friday 6:30pm-7:30pm, Saturday 11am-12pm").
+    day_pairs = _day_of_week_events(doc, times_str)
+    if day_pairs:
+        return [make_event(*pair) for pair in day_pairs]
 
-    # Fall back to all-day with freeform times prepended to description.
-    all_day_desc = description
-    if times_str and "see event description" not in times_str.lower():
-        all_day_desc = f"{times_str} — {description}" if description else times_str
+    # Strategy 4: fall back to all-day with freeform times prepended to description.
+    all_day_desc = _fallback_all_day_desc(times_str, description)
     return [make_event(datetime.combine(event_date, dtime.min, tzinfo=_CENTRAL), all_day=True, desc=all_day_desc)]

--- a/backend/tests/test_visit_madison.py
+++ b/backend/tests/test_visit_madison.py
@@ -1,0 +1,165 @@
+"""Unit tests for visit_madison.py time-parsing strategy helpers."""
+from datetime import date, datetime, time as dtime, timedelta
+from zoneinfo import ZoneInfo
+
+from app.scrapers.visit_madison import (
+    _CENTRAL,
+    _day_of_week_events,
+    _fallback_all_day_desc,
+    _parse_from_to_times,
+    _top_level_times,
+)
+
+_DATE = date(2026, 5, 8)  # a Friday
+
+
+# ---------------------------------------------------------------------------
+# _top_level_times
+# ---------------------------------------------------------------------------
+
+class TestTopLevelTimes:
+    def _doc(self, start=None, end=None):
+        return {"startTime": start, "endTime": end}
+
+    def test_no_start_time_returns_none(self):
+        assert _top_level_times({}, _DATE) is None
+
+    def test_empty_start_time_returns_none(self):
+        assert _top_level_times(self._doc(start=""), _DATE) is None
+
+    def test_start_only(self):
+        result = _top_level_times(self._doc(start="18:30:00"), _DATE)
+        assert result is not None
+        start_at, end_at = result
+        assert start_at == datetime.combine(_DATE, dtime(18, 30, 0), tzinfo=_CENTRAL)
+        assert end_at is None
+
+    def test_start_and_end(self):
+        result = _top_level_times(self._doc(start="18:00:00", end="20:00:00"), _DATE)
+        assert result is not None
+        start_at, end_at = result
+        assert start_at == datetime.combine(_DATE, dtime(18, 0, 0), tzinfo=_CENTRAL)
+        assert end_at == datetime.combine(_DATE, dtime(20, 0, 0), tzinfo=_CENTRAL)
+
+    def test_midnight_wrap_when_end_before_start(self):
+        # Event that runs from 11pm to 1am — end_at should be next day.
+        result = _top_level_times(self._doc(start="23:00:00", end="01:00:00"), _DATE)
+        assert result is not None
+        start_at, end_at = result
+        assert end_at == datetime.combine(_DATE + timedelta(days=1), dtime(1, 0, 0), tzinfo=_CENTRAL)
+        assert end_at > start_at
+
+
+# ---------------------------------------------------------------------------
+# _parse_from_to_times  (Strategy 2)
+# ---------------------------------------------------------------------------
+
+class TestParseFromToTimes:
+    def test_standard_range(self):
+        result = _parse_from_to_times("From: 06:00 PM to 08:30 PM", _DATE)
+        assert result is not None
+        start_at, end_at = result
+        assert start_at == datetime.combine(_DATE, dtime(18, 0, 0), tzinfo=_CENTRAL)
+        assert end_at == datetime.combine(_DATE, dtime(20, 30, 0), tzinfo=_CENTRAL)
+
+    def test_no_match_returns_none(self):
+        assert _parse_from_to_times("Doors open at 7pm", _DATE) is None
+
+    def test_midnight_wrap(self):
+        result = _parse_from_to_times("From: 11:00 PM to 01:00 AM", _DATE)
+        assert result is not None
+        start_at, end_at = result
+        assert end_at == datetime.combine(_DATE + timedelta(days=1), dtime(1, 0, 0), tzinfo=_CENTRAL)
+
+    def test_case_insensitive(self):
+        result = _parse_from_to_times("from: 02:00 pm to 04:00 pm", _DATE)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _day_of_week_events  (Strategy 3)
+# ---------------------------------------------------------------------------
+
+def _iso_z(d: date) -> str:
+    """Build a simple UTC ISO string at midnight Central (approximated as T06:00Z)."""
+    return datetime(d.year, d.month, d.day, 6, 0, 0, tzinfo=ZoneInfo("UTC")).isoformat().replace("+00:00", "Z")
+
+
+class TestDayOfWeekEvents:
+    def _doc(self, start: date, end: date):
+        return {"startDate": _iso_z(start), "endDate": _iso_z(end)}
+
+    def test_no_times_str_returns_empty(self):
+        doc = self._doc(date(2026, 5, 1), date(2026, 5, 31))
+        assert _day_of_week_events(doc, "") == []
+
+    def test_no_start_date_returns_empty(self):
+        assert _day_of_week_events({}, "Friday 6:30pm-7:30pm") == []
+
+    def test_no_matching_days_in_range(self):
+        # Range is a single Monday; looking for Friday — no match.
+        doc = self._doc(date(2026, 5, 4), date(2026, 5, 4))  # Monday only
+        result = _day_of_week_events(doc, "Friday 6:30pm-7:30pm")
+        assert result == []
+
+    def test_single_day_match(self):
+        # Range covers exactly one Friday (May 8 2026).
+        doc = self._doc(date(2026, 5, 4), date(2026, 5, 10))
+        result = _day_of_week_events(doc, "Friday 6:30pm-7:30pm")
+        assert len(result) == 1
+        start_at, end_at = result[0]
+        assert start_at.date() == date(2026, 5, 8)
+        assert start_at.time() == dtime(18, 30, 0)
+        assert end_at.time() == dtime(19, 30, 0)
+        assert start_at.tzinfo is not None
+
+    def test_multiple_weekday_matches(self):
+        # Two-week range should hit two Fridays.
+        doc = self._doc(date(2026, 5, 1), date(2026, 5, 14))
+        result = _day_of_week_events(doc, "Friday 6:30pm-7:30pm")
+        assert len(result) == 2
+
+    def test_multiple_day_types(self):
+        # "Friday 6:30pm-7:30pm, Saturday 11am-12pm" over one week.
+        doc = self._doc(date(2026, 5, 4), date(2026, 5, 10))
+        result = _day_of_week_events(doc, "Friday 6:30pm-7:30pm, Saturday 11am-12pm")
+        assert len(result) == 2
+        days = {r[0].date() for r in result}
+        assert date(2026, 5, 8) in days   # Friday
+        assert date(2026, 5, 9) in days   # Saturday
+
+    def test_midnight_wrap(self):
+        doc = self._doc(date(2026, 5, 4), date(2026, 5, 10))
+        result = _day_of_week_events(doc, "Friday 11pm-1am")
+        assert len(result) == 1
+        start_at, end_at = result[0]
+        assert end_at > start_at
+        assert end_at.date() == date(2026, 5, 9)  # next day
+
+
+# ---------------------------------------------------------------------------
+# _fallback_all_day_desc  (Strategy 4)
+# ---------------------------------------------------------------------------
+
+class TestFallbackAllDayDesc:
+    def test_no_times_str_returns_description(self):
+        assert _fallback_all_day_desc("", "Some description") == "Some description"
+
+    def test_times_prepended_to_description(self):
+        result = _fallback_all_day_desc("7pm-9pm", "Great event")
+        assert result == "7pm-9pm — Great event"
+
+    def test_times_only_when_no_description(self):
+        result = _fallback_all_day_desc("7pm-9pm", None)
+        assert result == "7pm-9pm"
+
+    def test_see_event_description_passthrough(self):
+        result = _fallback_all_day_desc("See event description for times", "My desc")
+        assert result == "My desc"
+
+    def test_see_event_description_case_insensitive(self):
+        result = _fallback_all_day_desc("SEE EVENT DESCRIPTION", "My desc")
+        assert result == "My desc"
+
+    def test_empty_times_with_none_description(self):
+        assert _fallback_all_day_desc("", None) is None


### PR DESCRIPTION
Closes #41

## Summary

- Extracted three named helper functions from the 72-line `_to_raw_events` in `backend/app/scrapers/visit_madison.py`, which previously handled four time-parsing strategies entirely inline:
  - `_top_level_times(doc, event_date)` — strategy 1: top-level HMS startTime/endTime fields
  - `_day_of_week_events(doc, times_str)` — strategy 3: day-of-week recurrence (e.g. "Friday 6:30pm-7:30pm")
  - `_fallback_all_day_desc(times_str, description)` — strategy 4: all-day fallback description
- Strategy 2 (`_parse_from_to_times`) was already a standalone function; `_to_raw_events` now calls it directly from a slim dispatch body
- Pure refactor — behavior is identical to before
- Added `backend/tests/test_visit_madison.py` with 22 unit tests covering all four strategies and edge cases (midnight wrap, missing fields, no-match inputs, case insensitivity)

## Verification
- [x] 22 new unit tests in `tests/test_visit_madison.py` — all pass
- [x] Full test suite (29 tests) — all pass
- [x] Ruff lint — clean
- [x] `_to_raw_events` reduced from 72 lines to ~35 lines (dispatch body only)