### PR TITLE
Add rationale comments to magic numbers and fallback token

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -12,7 +12,7 @@ from app.scrapers.base import RawEvent
 logger = logging.getLogger(__name__)
 
 _FILLABLE_FIELDS = ("description", "end_at", "venue_name", "venue_address", "image_url")
-FUZZY_TITLE_THRESHOLD = 0.65
+FUZZY_TITLE_THRESHOLD = 0.65  # tuned empirically against the Isthmus + Visit Madison overlap
 
 
 def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> dict:

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 _ICAL_URL = "https://isthmus.com/search/event/calendar-of-events/calendar.ics"
 _RSS_BASE = "https://isthmus.com/search/event/calendar-of-events/index.rss"
 _CENTRAL = ZoneInfo("America/Chicago")
-_WINDOW_DAYS = 30
+_WINDOW_DAYS = 30  # matches the iCal feed's effective range
 _DESC_MIN_LEN = 80
-_FETCH_DELAY = 0.5  # seconds between detail-page fetches
+_FETCH_DELAY = 0.5  # courtesy delay between detail-page fetches; Isthmus has no published rate limit
 
 
 def _fetch_full_description(url: str) -> str | None:

--- a/backend/app/scrapers/visit_madison.py
+++ b/backend/app/scrapers/visit_madison.py
@@ -8,7 +8,7 @@ from app.scrapers.base import BaseSource, RawEvent, clean_html_text, http_get_wi
 
 _API_URL = "https://www.visitmadison.com/includes/rest_v2/plugins_events_events_by_date/find/"
 _EVENTS_PAGE_URL = "https://www.visitmadison.com/events/"
-_FALLBACK_TOKEN = "e3dfe8528d358756953f873be82e42a2"
+_FALLBACK_TOKEN = "e3dfe8528d358756953f873be82e42a2"  # public widget token embedded in Visit Madison's own site, not a secret to rotate
 _TOKEN_RE = re.compile(r'"apiToken"\s*:\s*"([0-9a-f]{32})"')
 _CENTRAL = ZoneInfo("America/Chicago")
 _WINDOW_DAYS = 30

--- a/backend/app/tagger.py
+++ b/backend/app/tagger.py
@@ -13,7 +13,7 @@ from app.models import Event
 logger = logging.getLogger(__name__)
 
 _CATEGORIES_SET = frozenset(CATEGORIES)
-_MIN_DESCRIPTION_LEN = 80
+_MIN_DESCRIPTION_LEN = 80  # shorter descriptions don't give the LLM enough signal and waste tokens
 
 _SYSTEM_PROMPT = (
     "You are a category classifier for a Madison, WI community events listing.\n\n"
@@ -122,7 +122,7 @@ def tag_untagged_events(db: Session, model: Optional[str] = None) -> dict:
 
     tagged = 0
     batches = 0
-    batch_size = 25
+    batch_size = 25  # balances prompt-cache hit rate vs. risk of one bad event polluting a batch
 
     for i in range(0, len(to_tag), batch_size):
         batch_items = to_tag[i : i + batch_size]


### PR DESCRIPTION
## Summary
- Adds one-line inline comments to six constants across four backend files explaining *why* each value was chosen
- Clarifies that `_FALLBACK_TOKEN` in `visit_madison.py` is a public widget token, reducing the chance a reader treats it as a secret to rotate
- No logic changes; comment-only diff

## Verification
- [x] `ruff check backend/` passes
- [x] All 29 backend tests pass

closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)