### PR TITLE
Frontend polish: index.html title, meta description, VITE_BACKEND_URL proxy override

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <meta name="description" content="Discover events happening in Madison, WI" />
+    <title>What's Up Madison</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const backendUrl = process.env.VITE_BACKEND_URL || 'http://localhost:8000'
+
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
-      '/events': 'http://localhost:8000',
-      '/admin': 'http://localhost:8000',
+      '/events': backendUrl,
+      '/admin': backendUrl,
     },
   },
 })


### PR DESCRIPTION
Addresses the three polish items from issue #43.

## Changes

- **`frontend/index.html`**: Changed `<title>` from the Vite scaffold placeholder `"frontend"` to `"What's Up Madison"`; added missing `<meta name="description" content="Discover events happening in Madison, WI">`.
- **`frontend/vite.config.js`**: Extracted proxy target into a `backendUrl` const that reads `VITE_BACKEND_URL` env var with fallback to `http://localhost:8000`. Both `/events` and `/admin` proxy entries use it, so a non-default backend port no longer requires editing the config file.
- **`frontend/public/favicon.svg`**: Already existed — no change needed. The `<link rel="icon">` in `index.html` is correct and will not 404.

closes #43

## Verification

- [x] `index.html` contains `<title>What's Up Madison</title>` and `<meta name="description">` — confirmed via grep
- [x] `vite.config.js` references `VITE_BACKEND_URL` — confirmed via grep
- [x] Vite `--debug` output with `VITE_BACKEND_URL=http://localhost:8001` shows both proxy entries resolving to port 8001
- [x] Lint (`ruff check backend/`) passes — all checks passed
- [x] Backend tests (`pytest backend/tests/ -v`) pass — 29/29
- [ ] Browser tab title reads "What's Up Madison" (`npm run dev`)
- [ ] Favicon renders in browser tab (no console 404 for `/favicon.svg`)