### PR TITLE
Add free/paid cost indicator badge to event cards and modal

### DIFF
--- a/frontend/src/components/AllDayStrip.jsx
+++ b/frontend/src/components/AllDayStrip.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventModal from './EventModal'
 import EventActionButtons from './EventActionButtons'
+import CostBadge from './CostBadge'
 
 export default function AllDayStrip({ events, stickyTop }) {
   if (!events || events.length === 0) return null
@@ -50,7 +51,8 @@ function AllDayCard({ event }) {
           ) : (
             <h3 className="text-sm font-semibold text-gray-900 leading-snug line-clamp-2 flex-1 min-w-0">{event.title}</h3>
           )}
-          <div className="flex items-center gap-0.5 flex-shrink-0 ml-1">
+          <div className="flex items-center gap-1 flex-shrink-0 ml-1">
+            <CostBadge description={event.description} />
             <EventActionButtons event={event} compact />
           </div>
         </div>

--- a/frontend/src/components/CostBadge.jsx
+++ b/frontend/src/components/CostBadge.jsx
@@ -1,0 +1,20 @@
+import { getCostIndicator } from '../lib/costIndicator'
+
+export default function CostBadge({ description }) {
+  const indicator = getCostIndicator(description)
+  if (!indicator) return null
+
+  if (indicator === 'free') {
+    return (
+      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 font-medium leading-none flex-shrink-0">
+        Free
+      </span>
+    )
+  }
+
+  return (
+    <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 font-medium leading-none flex-shrink-0">
+      $
+    </span>
+  )
+}

--- a/frontend/src/components/EventCard.jsx
+++ b/frontend/src/components/EventCard.jsx
@@ -3,6 +3,7 @@ import { formatTimeRange } from '../lib/eventTime'
 import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventModal from './EventModal'
 import EventActionButtons from './EventActionButtons'
+import CostBadge from './CostBadge'
 
 export default function EventCard({ event }) {
   const [modalOpen, setModalOpen] = useState(false)
@@ -18,7 +19,10 @@ export default function EventCard({ event }) {
         onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalOpen(true) } }}
       >
         <div className="flex items-start justify-between mb-0.5">
-          <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-xs text-gray-400">{formatTimeRange(event.start_at, event.end_at)}</p>
+            <CostBadge description={event.description} />
+          </div>
           <div className="flex items-center gap-0.5 ml-2 flex-shrink-0">
             <EventActionButtons event={event} />
           </div>

--- a/frontend/src/components/EventModal.jsx
+++ b/frontend/src/components/EventModal.jsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react'
 import { formatTimeRange } from '../lib/eventTime'
 import { sortedSources, isSafeHttpUrl } from '../lib/sources'
 import EventActionButtons from './EventActionButtons'
+import CostBadge from './CostBadge'
 
 export default function EventModal({ event, onClose }) {
   const sources = sortedSources(event.sources)
@@ -59,9 +60,13 @@ export default function EventModal({ event, onClose }) {
                 )}
               </div>
             ) : (
-              <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+              <div className="flex items-center gap-1.5">
+                <p className="text-xs text-gray-400 mt-0.5">{formatTimeRange(event.start_at, event.end_at)}</p>
+                <CostBadge description={event.description} />
+              </div>
             )}
             <div className="flex items-center gap-0.5 flex-shrink-0">
+              {event.all_day && <CostBadge description={event.description} />}
               <EventActionButtons event={event} />
               <button
                 className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer ml-1"

--- a/frontend/src/lib/costIndicator.js
+++ b/frontend/src/lib/costIndicator.js
@@ -1,0 +1,6 @@
+export function getCostIndicator(description) {
+  if (!description) return null
+  if (/\bfree\b/i.test(description)) return 'free'
+  if (/\$/.test(description)) return 'paid'
+  return null
+}


### PR DESCRIPTION
## Summary

- Adds a green **Free** badge or amber **$** badge to event cards and the event detail modal, so users can quickly see whether an event is free or costs money
- When neither signal is found in the description, no badge is shown
- Detection is purely frontend (no DB changes): scans `event.description` for `\bfree\b` (case-insensitive) or any `$` character; free takes priority if both appear

## Implementation

- `frontend/src/lib/costIndicator.js` — new `getCostIndicator(description)` utility returning `'free'`, `'paid'`, or `null`
- `frontend/src/components/CostBadge.jsx` — new component rendering the appropriate pill badge (or nothing for unknown)
- `EventCard.jsx` — badge placed next to the time in the card header row
- `AllDayStrip.jsx` (AllDayCard) — badge placed in the action-button cluster (no time row on all-day cards)
- `EventModal.jsx` — badge next to time (timed events) or in the header cluster (all-day events)

## Verification

- [x] `npm run build` passes (Vite, no errors)
- [x] `ruff check backend/` passes
- [x] All 29 backend tests pass (`pytest backend/tests/ -v`)
- [x] Open http://localhost:5173 and find an event with "free" in its description — confirm a green **Free** badge appears on the card and in the modal
- [x] Find an event with a "$" price in its description — confirm an amber **$** badge appears
- [x] Find an event with no cost signal — confirm no badge is shown
- [x] Confirm badges appear correctly in the All Day / Time Varies strip

closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)