### PR TITLE
Add ESLint to CI and fix pre-existing frontend lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ jobs:
       - run: pip install ruff
       - run: ruff check backend/
 
+  frontend-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run lint
+        working-directory: frontend
+
   test:
     runs-on: ubuntu-latest
     needs: lint

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -18,4 +18,8 @@ export default defineConfig([
       parserOptions: { ecmaFeatures: { jsx: true } },
     },
   },
+  {
+    files: ['vite.config.js'],
+    languageOptions: { globals: globals.node },
+  },
 ])

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -67,6 +67,7 @@ export default function App() {
   }, [])
 
   useLayoutEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!railEl) { setRailH(0); return }
     setRailH(railEl.offsetHeight)
     const ro = new ResizeObserver(() => setRailH(railEl.offsetHeight))
@@ -75,6 +76,7 @@ export default function App() {
   }, [railEl])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true)
     setError(null)
     fetch(`/events?date=${selectedDate}`)


### PR DESCRIPTION
## Summary

- Adds a `frontend-lint` job to CI that runs `npm ci && npm run lint` in the `frontend/` directory on every push and PR
- Fixes the 3 pre-existing ESLint errors that would have immediately broken the new job

**Fixes:**
- `eslint.config.js`: added a node-globals override block for `vite.config.js` so `process.env` is recognised (config was browser-only globals)
- `App.jsx` (×2): added `eslint-disable-next-line react-hooks/set-state-in-effect` on two intentional patterns — ResizeObserver height reset and fetch loading flag — both are correct uses that the react-hooks v7 rule over-flags

## Verification
- [x] `eslint .` in `frontend/` passes with zero errors locally
- [x] `ruff check backend/` still passes
- [x] All 29 backend tests pass