### PR TITLE
Make page title clickable to reset to today's date

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -128,7 +128,13 @@ export default function App() {
     <div className="min-h-screen bg-gray-50">
       <div ref={headerRef} className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3">
-          <h1 className="text-lg font-bold text-gray-900">What's Up Madison</h1>
+          <button
+            type="button"
+            onClick={() => setSelectedDate(toLocalDateString(new Date()))}
+            className="text-lg font-bold text-gray-900 hover:text-gray-600 cursor-pointer transition-colors"
+          >
+            What's Up Madison
+          </button>
           <div className="flex items-center gap-2">
             <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
               <button


### PR DESCRIPTION
## Summary
- Converts the static `What's Up Madison` `<h1>` in the sticky header into a button that resets the selected date to today when clicked
- Uses the same `toLocalDateString(new Date())` call already used on initial load — timezone behavior is identical
- Hover style (subtle color shift + pointer cursor) signals interactivity without changing the header's visual weight

closes #63

## Verification
- [x] Frontend ESLint passes (`npm run lint`)
- [x] Backend ruff passes (`ruff check backend/`)
- [x] All 29 backend tests pass (`pytest backend/tests/`)
- [x] Navigate to a future or past date, click "What's Up Madison" — confirm date resets to today and today's events load
- [x] Confirm the title shows a pointer cursor and subtle color change on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)