### PR TITLE
Fix crowded title bar: move List/Map toggle to title row on mobile

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -129,42 +129,44 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gray-50">
       <div ref={headerRef} className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col items-center gap-y-1 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
           <button
             type="button"
             onClick={() => setSelectedDate(toLocalDateString(new Date()))}
-            className="text-lg font-bold text-gray-900 hover:text-gray-600 cursor-pointer transition-colors flex-1 sm:flex-none"
+            className="text-lg font-bold text-gray-900 hover:text-gray-600 cursor-pointer transition-colors"
           >
             What's Up Madison
           </button>
-          <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
-            <button
-              type="button"
-              onClick={() => setViewMode('list')}
-              className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-            >
-              List
-            </button>
-            <button
-              type="button"
-              onClick={() => setViewMode('map')}
-              className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-            >
-              Map
-            </button>
-          </div>
-          <div className="w-full sm:w-auto sm:ml-auto flex items-center gap-2">
-            <CategoryFilter
-              selected={filter.selected}
-              includeUncategorized={filter.includeUncategorized}
-              onChange={setFilter}
-            />
-            <VenueFilter
-              allVenues={allVenues}
-              hiddenVenues={hiddenVenues}
-              onChange={setHiddenVenues}
-            />
-            <DatePicker value={selectedDate} onChange={setSelectedDate} />
+          <div className="flex flex-wrap justify-center sm:flex-nowrap sm:justify-start items-center gap-2">
+            <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
+              <button
+                type="button"
+                onClick={() => setViewMode('list')}
+                className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+              >
+                List
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('map')}
+                className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+              >
+                Map
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <CategoryFilter
+                selected={filter.selected}
+                includeUncategorized={filter.includeUncategorized}
+                onChange={setFilter}
+              />
+              <VenueFilter
+                allVenues={allVenues}
+                hiddenVenues={hiddenVenues}
+                onChange={setHiddenVenues}
+              />
+              <DatePicker value={selectedDate} onChange={setSelectedDate} />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -129,31 +129,31 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gray-50">
       <div ref={headerRef} className="sticky top-0 z-30 bg-gray-50/95 backdrop-blur border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3">
+        <div className="max-w-7xl mx-auto px-4 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
           <button
             type="button"
             onClick={() => setSelectedDate(toLocalDateString(new Date()))}
-            className="text-lg font-bold text-gray-900 hover:text-gray-600 cursor-pointer transition-colors"
+            className="text-lg font-bold text-gray-900 hover:text-gray-600 cursor-pointer transition-colors flex-1 sm:flex-none"
           >
             What's Up Madison
           </button>
-          <div className="flex items-center gap-2">
-            <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
-              <button
-                type="button"
-                onClick={() => setViewMode('list')}
-                className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-              >
-                List
-              </button>
-              <button
-                type="button"
-                onClick={() => setViewMode('map')}
-                className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-              >
-                Map
-              </button>
-            </div>
+          <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
+            <button
+              type="button"
+              onClick={() => setViewMode('list')}
+              className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+            >
+              List
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode('map')}
+              className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+            >
+              Map
+            </button>
+          </div>
+          <div className="w-full sm:w-auto sm:ml-auto flex items-center gap-2">
             <CategoryFilter
               selected={filter.selected}
               includeUncategorized={filter.includeUncategorized}

--- a/frontend/src/components/CategoryFilter.jsx
+++ b/frontend/src/components/CategoryFilter.jsx
@@ -83,7 +83,7 @@ export default function CategoryFilter({
         >
           <path strokeLinecap="round" strokeLinejoin="round" d="M3 4h18M7 8h10M11 12h2M11 16h2" />
         </svg>
-        <span>Categories</span>
+        <span className="hidden sm:inline">Categories</span>
         {showBadge && (
           <span className="text-[10px] px-1 py-0.5 rounded-full bg-blue-600 text-white leading-none">
             {hiddenCount} hidden


### PR DESCRIPTION
## Summary

- On narrow phones, the header controls row was a single unwrapped flex div that overflowed the viewport, clipping the List/Map buttons.
- Restructured the header in `App.jsx`: title is always centered on mobile (`flex-col items-center`); controls sit in a `flex-wrap justify-center` row beneath it.
- Controls wrap in priority order — CategoryFilter, VenueFilter, and DatePicker are grouped in a single inner div so they wrap together as a unit. This means List/Map is always the first element to get its own centered row when space is tight, rather than the DatePicker breaking off by itself.
- On desktop (`sm+`) the layout is unchanged: title left, controls right.
- In `CategoryFilter.jsx`, the Categories text label is hidden on mobile (icon only) to keep the filters row compact on narrow screens.

closes #89

## Verification

- [x] Frontend build (`npm run build`) passes
- [x] Backend lint (`ruff check backend/`) passes
- [x] Frontend lint (`npm run lint`) passes
- [x] All 29 backend tests pass
- [x] On a narrow screen (~375px): title centered, controls wrap to List/Map row then filters row
- [x] On a medium screen (~412px): all controls fit on one line beneath the title
- [x] On desktop: layout unchanged — title left, controls right
- [x] Toggle List/Map, open Category and Venue filter panels, change date — all interactions work correctly