### PR TITLE
Add attribution footer and in-page feedback form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,8 @@ Loaded from `backend/.env` (gitignored). See `backend/.env.example` for required
 
 `CORS_ORIGINS` must be a **comma-separated string**, not a JSON array. pydantic-settings v2 tries to JSON-parse `list[str]` fields from dotenv sources before validators run, which causes a `SettingsError` for non-JSON values. To avoid this, `cors_origins` is typed as `str` in `Settings` and exposed as a list via `settings.get_cors_origins()`. Do not change it back to `list[str]`.
 
+`GITHUB_TOKEN` is a GitHub Personal Access Token with `issues: write` scope. Used by `POST /feedback` to file user-submitted feedback as GitHub Issues labeled `user-feedback`. If unset, the endpoint returns HTTP 503. Not required in development if you don't need to test feedback submission.
+
 ## Frontend
 
 React + Vite + Tailwind CSS. Node deps are project-local (not in conda).
@@ -170,7 +172,7 @@ npm run dev      # dev server at http://localhost:5173
 npm run build    # production build
 ```
 
-`vite.config.js` proxies `/events` and `/admin` to `http://localhost:8000`, so no CORS issues in dev.
+`vite.config.js` proxies `/events`, `/admin`, and `/feedback` to `http://localhost:8000`, so no CORS issues in dev.
 
 ## Linting
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,5 @@ CORS_ORIGINS=http://localhost:5173,http://localhost:3000
 ANTHROPIC_API_KEY=your-key-here
 TAGGER_MODEL=claude-haiku-4-5
 ADMIN_API_KEY=your-admin-key-here
+# GitHub PAT with issues:write scope — used by POST /feedback to file user-submitted issues
+GITHUB_TOKEN=your-github-pat-here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,8 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     tagger_model: str = "claude-haiku-4-5"
     admin_api_key: str = ""
+    github_token: str = ""
+    github_repo: str = "linuxmaier/whats-up-madison"
 
     @model_validator(mode="after")
     def check_production_admin_key(self):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -97,7 +97,11 @@ async def submit_feedback(request: FeedbackRequest):
                 "Accept": "application/vnd.github+json",
                 "X-GitHub-Api-Version": "2022-11-28",
             },
-            json={"title": request.title, "body": request.body, "labels": ["user-feedback"]},
+            json={
+                "title": request.title,
+                "body": request.body + (f"\n\n---\n**Contact:** {request.contact}" if request.contact.strip() else ""),
+                "labels": ["user-feedback"],
+            },
         )
     if resp.status_code not in (200, 201):
         raise HTTPException(status_code=502, detail=f"GitHub API error: {resp.status_code}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ import logging.config
 from contextlib import asynccontextmanager
 from typing import Optional
 
+import httpx
 from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
@@ -13,6 +14,7 @@ from app.database import Base, engine, get_db
 from app.geocode_runner import geocode_all_missing, geocode_missing_for_source
 from app.ingest import ingest_events
 from app.routers import events
+from app.schemas import FeedbackRequest
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.visit_madison import VisitMadisonSource
 from app.tagger import tag_untagged_events
@@ -79,6 +81,27 @@ def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.post("/feedback")
+async def submit_feedback(request: FeedbackRequest):
+    if request.website:
+        return {"ok": True}
+    if not settings.github_token:
+        raise HTTPException(status_code=503, detail="Feedback submissions are not configured")
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(
+            f"https://api.github.com/repos/{settings.github_repo}/issues",
+            headers={
+                "Authorization": f"Bearer {settings.github_token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            json={"title": request.title, "body": request.body, "labels": ["user-feedback"]},
+        )
+    if resp.status_code not in (200, 201):
+        raise HTTPException(status_code=502, detail=f"GitHub API error: {resp.status_code}")
+    return {"ok": True, "issue_url": resp.json()["html_url"]}
 
 
 @app.post("/admin/scrape")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,7 +99,7 @@ async def submit_feedback(request: FeedbackRequest):
             },
             json={
                 "title": request.title,
-                "body": request.body + (f"\n\n---\n**Contact:** {request.contact}" if request.contact.strip() else ""),
+                "body": request.body + (f"\n\n---\n**Email:** {request.contact}" if request.contact.strip() else ""),
                 "labels": ["user-feedback"],
             },
         )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,7 +2,20 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+
+class FeedbackRequest(BaseModel):
+    title: str
+    body: str
+    website: str = ""  # honeypot — bots fill this; humans don't see it
+
+    @field_validator("title", "body")
+    @classmethod
+    def not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be blank")
+        return v
 
 
 class SourceRef(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, field_validator
 class FeedbackRequest(BaseModel):
     title: str
     body: str
+    contact: str = ""
     website: str = ""  # honeypot — bots fill this; humans don't see it
 
     @field_validator("title", "body")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import BucketSection from './components/BucketSection'
 import CategoryFilter from './components/CategoryFilter'
 import VenueFilter from './components/VenueFilter'
 import MapView from './components/MapView'
+import FeedbackModal from './components/FeedbackModal'
 import { partitionEvents } from './lib/eventTime'
 import {
   filterEvents,
@@ -53,6 +54,7 @@ export default function App() {
   const [filter, setFilter] = useState(loadFilterState)
   const [hiddenVenues, setHiddenVenues] = useState(loadHiddenVenues)
   const [viewMode, setViewMode] = useState(loadViewMode)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
 
   const headerRef = useRef(null)
   const [railEl, setRailEl] = useState(null)
@@ -215,6 +217,29 @@ export default function App() {
           )}
         </div>
       </div>
+
+      <footer className="border-t border-gray-200 mt-4">
+        <div className="max-w-7xl mx-auto px-4 py-3 flex items-center gap-3 text-xs text-gray-400">
+          <a
+            href="https://github.com/linuxmaier/whats-up-madison"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gray-600 transition-colors"
+          >
+            Open source
+          </a>
+          <span aria-hidden="true">·</span>
+          <button
+            type="button"
+            className="hover:text-gray-600 transition-colors cursor-pointer"
+            onClick={() => setFeedbackOpen(true)}
+          >
+            Submit feedback
+          </button>
+        </div>
+      </footer>
+
+      <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
     </div>
   )
 }

--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from 'lucide-react'
+
+const GITHUB_REPO = 'linuxmaier/whats-up-madison'
+const GITHUB_ISSUES_URL = `https://github.com/${GITHUB_REPO}/issues/new`
+
+export default function FeedbackModal({ open, onClose }) {
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const [status, setStatus] = useState('idle') // idle | submitting | success | error
+  const [issueUrl, setIssueUrl] = useState(null)
+  const dialogRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (!open) return
+    const previousFocus = document.activeElement
+    dialogRef.current?.focus()
+    return () => { previousFocus?.focus() }
+  }, [open])
+
+  function handleClose() {
+    setTitle('')
+    setBody('')
+    setHoneypot('')
+    setStatus('idle')
+    setIssueUrl(null)
+    onClose()
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setStatus('submitting')
+    try {
+      const res = await fetch('/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body, website: honeypot }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setIssueUrl(data.issue_url ?? null)
+      setStatus('success')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 flex items-center justify-center p-4"
+      style={{ zIndex: 10000 }}
+      onClick={handleClose}
+    >
+      <div className="absolute inset-0 bg-black/30" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-modal-title"
+        tabIndex={-1}
+        className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg focus:outline-none"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="px-5 py-4 flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h2 id="feedback-modal-title" className="text-base font-semibold text-gray-900">
+              Submit feedback
+            </h2>
+            <button
+              type="button"
+              className="text-gray-400 hover:text-gray-600 p-1 rounded cursor-pointer"
+              onClick={handleClose}
+              title="Close"
+            >
+              <X size={14} />
+            </button>
+          </div>
+
+          {status === 'success' ? (
+            <div className="flex flex-col gap-3 py-2">
+              <p className="text-sm text-gray-700">
+                Thanks! Your feedback was submitted as a GitHub issue.
+              </p>
+              {issueUrl && (
+                <a
+                  href={issueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-blue-600 hover:underline"
+                >
+                  View your issue ↗
+                </a>
+              )}
+              <button
+                type="button"
+                className="self-start text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
+                onClick={handleClose}
+              >
+                Close
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+              {/* honeypot — hidden from humans, bots fill it out */}
+              <div style={{ position: 'absolute', opacity: 0, top: '-9999px', left: '-9999px' }} aria-hidden="true">
+                <label htmlFor="feedback-website">Website</label>
+                <input
+                  id="feedback-website"
+                  type="text"
+                  name="website"
+                  value={honeypot}
+                  onChange={e => setHoneypot(e.target.value)}
+                  tabIndex={-1}
+                  autoComplete="off"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label htmlFor="feedback-title" className="text-sm font-medium text-gray-700">
+                  Title
+                </label>
+                <input
+                  id="feedback-title"
+                  type="text"
+                  required
+                  maxLength={100}
+                  value={title}
+                  onChange={e => setTitle(e.target.value)}
+                  placeholder="Short summary of your feedback"
+                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label htmlFor="feedback-body" className="text-sm font-medium text-gray-700">
+                  Details
+                </label>
+                <textarea
+                  id="feedback-body"
+                  required
+                  rows={5}
+                  value={body}
+                  onChange={e => setBody(e.target.value)}
+                  placeholder="Describe the bug or suggestion in more detail"
+                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-gray-400"
+                />
+              </div>
+
+              {status === 'error' && (
+                <p className="text-sm text-red-600">
+                  Something went wrong.{' '}
+                  <a
+                    href={GITHUB_ISSUES_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    Open an issue directly on GitHub ↗
+                  </a>
+                </p>
+              )}
+
+              <div className="flex items-center justify-end gap-3 pt-1">
+                <button
+                  type="button"
+                  className="text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
+                  onClick={handleClose}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={status === 'submitting'}
+                  className="bg-gray-800 text-white text-sm px-4 py-2 rounded-lg hover:bg-gray-700 disabled:opacity-50 cursor-pointer"
+                >
+                  {status === 'submitting' ? 'Submitting…' : 'Submit'}
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -163,14 +163,14 @@ export default function FeedbackModal({ open, onClose }) {
 
               <div className="flex flex-col gap-1">
                 <label htmlFor="feedback-contact" className="text-sm font-medium text-gray-700">
-                  Contact <span className="font-normal text-gray-400">(optional)</span>
+                  Email <span className="font-normal text-gray-400">(optional)</span>
                 </label>
                 <input
                   id="feedback-contact"
-                  type="text"
+                  type="email"
                   value={contact}
                   onChange={e => setContact(e.target.value)}
-                  placeholder="Email or other way to reach you"
+                  placeholder="your@email.com"
                   className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
                 />
               </div>

--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -8,6 +8,7 @@ const GITHUB_ISSUES_URL = `https://github.com/${GITHUB_REPO}/issues/new`
 export default function FeedbackModal({ open, onClose }) {
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
+  const [contact, setContact] = useState('')
   const [honeypot, setHoneypot] = useState('')
   const [status, setStatus] = useState('idle') // idle | submitting | success | error
   const [issueUrl, setIssueUrl] = useState(null)
@@ -32,6 +33,7 @@ export default function FeedbackModal({ open, onClose }) {
   function handleClose() {
     setTitle('')
     setBody('')
+    setContact('')
     setHoneypot('')
     setStatus('idle')
     setIssueUrl(null)
@@ -45,7 +47,7 @@ export default function FeedbackModal({ open, onClose }) {
       const res = await fetch('/feedback', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, body, website: honeypot }),
+        body: JSON.stringify({ title, body, contact, website: honeypot }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
@@ -156,6 +158,20 @@ export default function FeedbackModal({ open, onClose }) {
                   onChange={e => setBody(e.target.value)}
                   placeholder="Describe the bug or suggestion in more detail"
                   className="border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-gray-400"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <label htmlFor="feedback-contact" className="text-sm font-medium text-gray-700">
+                  Contact <span className="font-normal text-gray-400">(optional)</span>
+                </label>
+                <input
+                  id="feedback-contact"
+                  type="text"
+                  value={contact}
+                  onChange={e => setContact(e.target.value)}
+                  placeholder="Email or other way to reach you"
+                  className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-400"
                 />
               </div>
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     proxy: {
       '/events': backendUrl,
       '/admin': backendUrl,
+      '/feedback': backendUrl,
     },
   },
 })


### PR DESCRIPTION
## Summary

- Adds a `POST /feedback` endpoint to the FastAPI backend that creates a GitHub Issue via the GitHub API when users submit feedback, so all feedback lands directly in the issue tracker
- Adds an "Open source" link and "Submit feedback" button in a small footer at the bottom of every page
- `FeedbackModal` component handles a Title, Details, and optional Email field; shows loading state, success with a link to the created issue, and an error fallback
- Optional email field appended to the issue body under a `---` divider when provided (`**Email:** ...`); omitted entirely if left blank; uses `type="email"` so the browser validates the format
- Honeypot field silently drops bot submissions without revealing the rejection
- Requires `GITHUB_TOKEN` (PAT with `issues:write` scope) in `backend/.env`; the endpoint returns HTTP 503 if unset

closes #68

## Verification

- [x] `POST /feedback` with valid title+body creates a real GitHub issue labeled `user-feedback`
- [x] Email field appears in issue body as `**Email:** ...` when provided, omitted when blank
- [x] Honeypot test: `POST /feedback` with `website` field set returns `{"ok": true}` but creates no issue
- [x] `ruff check backend/` passes
- [x] `user-feedback` label created on the repo

## After merging — required setup

Add `GITHUB_TOKEN` to `backend/.env` in production (the Fly.io/Neon deployment):
```
GITHUB_TOKEN=<your-PAT-with-issues:write-scope>
```
Without it, the feedback endpoint returns 503 but the rest of the app is unaffected.

## Manual checks

- [x] Open the site in a browser — confirm the footer is visible with "Open source" link and "Submit feedback" button
- [x] Click "Submit feedback", fill in the form with an email, and submit — confirm the issue appears on GitHub with the `user-feedback` label and the email in the body
- [x] Confirm the modal shows the success state with a link to the created issue
- [x] Confirm the modal closes cleanly and focus returns to the page