### PR TITLE
Add High Noon Saloon scraper

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.geocode_runner import geocode_all_missing, geocode_missing_for_source
 from app.ingest import ingest_events
 from app.routers import events
 from app.schemas import FeedbackRequest
+from app.scrapers.high_noon import HighNoonSource
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.visit_madison import VisitMadisonSource
 from app.tagger import tag_untagged_events
@@ -68,7 +69,7 @@ app.add_middleware(
 
 app.include_router(events.router)
 
-SCRAPERS = [IsthmusSource(), VisitMadisonSource()]
+SCRAPERS = [IsthmusSource(), VisitMadisonSource(), HighNoonSource()]
 
 
 def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):

--- a/backend/app/scrapers/high_noon.py
+++ b/backend/app/scrapers/high_noon.py
@@ -1,0 +1,158 @@
+import logging
+import re
+from datetime import datetime, time as dtime
+from zoneinfo import ZoneInfo
+
+from bs4 import BeautifulSoup
+
+from app.scrapers.base import BaseSource, RawEvent, http_get_with_retry
+
+logger = logging.getLogger(__name__)
+
+_CALENDAR_URL = "https://high-noon.com/calendar/"
+_CENTRAL = ZoneInfo("America/Chicago")
+_VENUE_ADDRESS = "701 E. Washington Ave, Madison, WI 53703"
+_DATE_RE = re.compile(r"^([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})$")
+_SHOW_TIME_RE = re.compile(r"Show:\s*(\d{1,2}):(\d{2})\s*(am|pm)", re.IGNORECASE)
+_DOORS_TIME_RE = re.compile(r"Doors:\s*(\d{1,2}):(\d{2})\s*(am|pm)", re.IGNORECASE)
+_CLASSIFICATION_PREFIX = "tm_classifications-"
+
+# Conservative mapping: only High Noon classifications that map unambiguously
+# to our taxonomy. All music-genre slugs collapse to "Music"; ambiguous or
+# pure-origin tags (e.g. "local") are dropped so the LLM tagger can still
+# enrich them later if descriptions improve.
+_MUSIC_GENRE_SLUGS: frozenset[str] = frozenset({
+    "adult-contemporary", "alternative-rock", "americana", "bluegrass", "blues",
+    "country", "dance-electronic", "edm", "electro-pop", "folk", "funk",
+    "hip-hop-rap", "indie-folk", "indie-pop", "indie-rock", "jam", "metal",
+    "metal-rock", "music", "nu-metal", "pop", "punk", "rb", "reggae", "rock",
+    "ska", "soul", "trap",
+})
+_NON_MUSIC_MAP: dict[str, str] = {
+    "arts-theatre": "Theater & Stage",
+    "the-moth": "Talks & Learning",
+    "use-your-noggin": "Talks & Learning",
+    "nerd-nite": "Talks & Learning",
+}
+
+
+class HighNoonSource(BaseSource):
+    name = "High Noon Saloon"
+    scraper_type = "html"
+
+    def fetch(self) -> list[RawEvent]:
+        resp = http_get_with_retry(_CALENDAR_URL, timeout=30)
+        soup = BeautifulSoup(resp.content, "lxml")
+        events: list[RawEvent] = []
+        for card in soup.select("article.event-card"):
+            event = _parse_card(card)
+            if event is not None:
+                events.append(event)
+        return events
+
+
+def _text(card, selector: str) -> str | None:
+    el = card.select_one(selector)
+    if el is None:
+        return None
+    text = el.get_text(separator=" ", strip=True)
+    return text or None
+
+
+def _parse_date(text: str) -> datetime | None:
+    """Parse 'May 7, 2026' into a Central-time-aware datetime at midnight."""
+    m = _DATE_RE.match(text.strip())
+    if not m:
+        return None
+    try:
+        d = datetime.strptime(text.strip(), "%B %d, %Y").date()
+    except ValueError:
+        return None
+    return datetime.combine(d, dtime.min, tzinfo=_CENTRAL)
+
+
+def _extract_time(times_str: str) -> dtime | None:
+    """Prefer Show: HH:MM am|pm; fall back to Doors: HH:MM am|pm."""
+    for pattern in (_SHOW_TIME_RE, _DOORS_TIME_RE):
+        m = pattern.search(times_str)
+        if m:
+            try:
+                return datetime.strptime(
+                    f"{m.group(1)}:{m.group(2)} {m.group(3).upper()}", "%I:%M %p"
+                ).time()
+            except ValueError:
+                continue
+    return None
+
+
+def _extract_categories(card) -> list[str]:
+    seen: list[str] = []
+    for cls in card.get("class", []):
+        if not cls.startswith(_CLASSIFICATION_PREFIX):
+            continue
+        slug = cls[len(_CLASSIFICATION_PREFIX):]
+        mapped: str | None = None
+        if slug in _MUSIC_GENRE_SLUGS:
+            mapped = "Music"
+        elif slug in _NON_MUSIC_MAP:
+            mapped = _NON_MUSIC_MAP[slug]
+        if mapped and mapped not in seen:
+            seen.append(mapped)
+    return seen
+
+
+def _build_description(presented_by: str | None, supporting: str | None) -> str | None:
+    parts = [p for p in (presented_by, supporting) if p]
+    return "\n".join(parts) if parts else None
+
+
+def _parse_card(card) -> RawEvent | None:
+    title_el = card.select_one(".event-title a")
+    if title_el is None:
+        return None
+    title = title_el.get_text(strip=True)
+    source_url = title_el.get("href")
+    if not title or not source_url:
+        return None
+
+    date_text = _text(card, ".event-date")
+    if not date_text:
+        return None
+    base_dt = _parse_date(date_text)
+    if base_dt is None:
+        logger.warning("High Noon: unparseable event-date %r for %r", date_text, title)
+        return None
+
+    times_text = _text(card, ".event-times") or ""
+    show_time = _extract_time(times_text)
+    if show_time is not None:
+        start_at = base_dt.replace(hour=show_time.hour, minute=show_time.minute)
+        all_day = False
+    else:
+        start_at = base_dt
+        all_day = True
+
+    venue_name = _text(card, ".event-venue") or "High Noon Saloon"
+    venue_address = _VENUE_ADDRESS if venue_name.lower() == "high noon saloon" else None
+
+    description = _build_description(
+        _text(card, ".event-presented-by"),
+        _text(card, ".event-supporting-acts"),
+    )
+
+    image_el = card.select_one(".event-top img")
+    image_url = image_el.get("src") if image_el is not None else None
+
+    return RawEvent(
+        title=title,
+        start_at=start_at,
+        end_at=None,
+        venue_name=venue_name,
+        venue_address=venue_address,
+        description=description,
+        image_url=image_url,
+        categories=_extract_categories(card),
+        all_day=all_day,
+        source_name="High Noon Saloon",
+        source_url=source_url,
+    )

--- a/backend/tests/test_high_noon.py
+++ b/backend/tests/test_high_noon.py
@@ -1,0 +1,232 @@
+"""Unit tests for high_noon.py parsing helpers."""
+from datetime import datetime, time as dtime
+from zoneinfo import ZoneInfo
+
+from bs4 import BeautifulSoup
+
+from app.scrapers.high_noon import (
+    _CENTRAL,
+    _build_description,
+    _extract_categories,
+    _extract_time,
+    _parse_card,
+    _parse_date,
+)
+
+
+def _card(html: str):
+    """Return the parsed <article.event-card> element from the given fragment."""
+    return BeautifulSoup(html, "lxml").select_one("article.event-card")
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+class TestParseDate:
+    def test_valid_date(self):
+        result = _parse_date("May 7, 2026")
+        assert result == datetime(2026, 5, 7, 0, 0, tzinfo=_CENTRAL)
+
+    def test_date_with_extra_whitespace(self):
+        assert _parse_date("  May 7, 2026  ") == datetime(2026, 5, 7, tzinfo=_CENTRAL)
+
+    def test_dst_winter_offset(self):
+        # December → Central Standard Time (UTC-6)
+        result = _parse_date("December 16, 2026")
+        assert result is not None
+        assert result.utcoffset().total_seconds() == -6 * 3600
+
+    def test_dst_summer_offset(self):
+        # July → Central Daylight Time (UTC-5)
+        result = _parse_date("July 4, 2026")
+        assert result is not None
+        assert result.utcoffset().total_seconds() == -5 * 3600
+
+    def test_invalid_returns_none(self):
+        assert _parse_date("Tomorrow") is None
+        assert _parse_date("2026-05-07") is None
+        assert _parse_date("") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_time
+# ---------------------------------------------------------------------------
+
+class TestExtractTime:
+    def test_show_preferred_over_doors(self):
+        # When both are present, Show wins.
+        assert _extract_time("Doors: 7:00 pm | Show: 8:00 pm") == dtime(20, 0)
+
+    def test_show_only(self):
+        assert _extract_time("Show: 4:00 pm") == dtime(16, 0)
+
+    def test_doors_only_fallback(self):
+        # Falls back to Doors when no Show is present.
+        assert _extract_time("Doors: 6:30 pm") == dtime(18, 30)
+
+    def test_morning_time(self):
+        assert _extract_time("Doors: 10:00 am | Show: 10:30 am") == dtime(10, 30)
+
+    def test_case_insensitive(self):
+        assert _extract_time("DOORS: 7:00 PM | SHOW: 8:00 PM") == dtime(20, 0)
+
+    def test_no_match_returns_none(self):
+        assert _extract_time("") is None
+        assert _extract_time("Time TBA") is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_categories
+# ---------------------------------------------------------------------------
+
+class TestExtractCategories:
+    def test_music_genre_collapses_to_music(self):
+        card = _card('<article class="event-card tm_classifications-country"></article>')
+        assert _extract_categories(card) == ["Music"]
+
+    def test_multiple_genres_dedup_to_music(self):
+        card = _card(
+            '<article class="event-card tm_classifications-rock '
+            'tm_classifications-punk tm_classifications-indie-rock"></article>'
+        )
+        assert _extract_categories(card) == ["Music"]
+
+    def test_the_moth_maps_to_talks(self):
+        card = _card(
+            '<article class="event-card tm_classifications-the-moth '
+            'tm_classifications-use-your-noggin"></article>'
+        )
+        assert _extract_categories(card) == ["Talks & Learning"]
+
+    def test_arts_theatre_maps(self):
+        card = _card('<article class="event-card tm_classifications-arts-theatre"></article>')
+        assert _extract_categories(card) == ["Theater & Stage"]
+
+    def test_community_civic_dropped(self):
+        # community-civic is used loosely by the source (e.g. for music
+        # showcases) — we intentionally drop it.
+        card = _card('<article class="event-card tm_classifications-community-civic"></article>')
+        assert _extract_categories(card) == []
+
+    def test_unknown_classification_dropped(self):
+        card = _card('<article class="event-card tm_classifications-mystery-genre"></article>')
+        assert _extract_categories(card) == []
+
+    def test_local_origin_tag_dropped(self):
+        card = _card(
+            '<article class="event-card tm_classifications-local '
+            'tm_classifications-bluegrass"></article>'
+        )
+        assert _extract_categories(card) == ["Music"]
+
+    def test_no_classifications(self):
+        card = _card('<article class="event-card tm_event"></article>')
+        assert _extract_categories(card) == []
+
+
+# ---------------------------------------------------------------------------
+# _build_description
+# ---------------------------------------------------------------------------
+
+class TestBuildDescription:
+    def test_both_parts(self):
+        assert _build_description("FPC LIVE PRESENTS", "with Kaleb Sanders") == \
+            "FPC LIVE PRESENTS\nwith Kaleb Sanders"
+
+    def test_presented_only(self):
+        assert _build_description("THE MOTH", None) == "THE MOTH"
+
+    def test_supporting_only(self):
+        assert _build_description(None, "with openers") == "with openers"
+
+    def test_neither(self):
+        assert _build_description(None, None) is None
+        assert _build_description("", "") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_card (integration of the helpers above against representative HTML)
+# ---------------------------------------------------------------------------
+
+_FULL_CARD_HTML = """
+<article class="event-card post-6559 tm_event tm_classifications-country tm_venues-high-noon-saloon">
+  <div class="event-inner">
+    <div class="event-top">
+      <a href="https://high-noon.com/event/kylie-morgan/">
+        <img src="https://example.com/poster.jpg"/>
+      </a>
+    </div>
+    <div class="event-bottom">
+      <div class="event-presented-by">FPC LIVE PRESENTS</div>
+      <div class="event-title"><a href="https://high-noon.com/event/kylie-morgan/">Kylie Morgan</a></div>
+      <div class="event-supporting-acts">with Kaleb Sanders</div>
+      <div class="event-venue">High Noon Saloon</div>
+      <div class="event-date">May 7, 2026</div>
+      <div class="event-times">Doors: 7:00 pm | Show: 8:00 pm</div>
+    </div>
+  </div>
+</article>
+"""
+
+
+class TestParseCard:
+    def test_full_card(self):
+        ev = _parse_card(_card(_FULL_CARD_HTML))
+        assert ev is not None
+        assert ev.title == "Kylie Morgan"
+        assert ev.start_at == datetime(2026, 5, 7, 20, 0, tzinfo=_CENTRAL)
+        assert ev.all_day is False
+        assert ev.venue_name == "High Noon Saloon"
+        assert ev.venue_address == "701 E. Washington Ave, Madison, WI 53703"
+        assert ev.description == "FPC LIVE PRESENTS\nwith Kaleb Sanders"
+        assert ev.image_url == "https://example.com/poster.jpg"
+        assert ev.categories == ["Music"]
+        assert ev.source_name == "High Noon Saloon"
+        assert ev.source_url == "https://high-noon.com/event/kylie-morgan/"
+
+    def test_missing_time_falls_back_to_all_day(self):
+        html = _FULL_CARD_HTML.replace(
+            "Doors: 7:00 pm | Show: 8:00 pm", "Time TBA"
+        )
+        ev = _parse_card(_card(html))
+        assert ev is not None
+        assert ev.all_day is True
+        assert ev.start_at == datetime(2026, 5, 7, 0, 0, tzinfo=_CENTRAL)
+
+    def test_missing_date_skips_card(self):
+        html = _FULL_CARD_HTML.replace("May 7, 2026", "")
+        assert _parse_card(_card(html)) is None
+
+    def test_missing_title_skips_card(self):
+        html = _FULL_CARD_HTML.replace(
+            '<a href="https://high-noon.com/event/kylie-morgan/">Kylie Morgan</a>',
+            '',
+            # only inside .event-title
+        )
+        # The .event-title still contains its outer div but no <a>; _parse_card returns None.
+        assert _parse_card(_card(html)) is None
+
+    def test_non_high_noon_venue_no_address(self):
+        html = _FULL_CARD_HTML.replace(
+            "<div class=\"event-venue\">High Noon Saloon</div>",
+            "<div class=\"event-venue\">High Noon Patio</div>",
+        )
+        ev = _parse_card(_card(html))
+        assert ev is not None
+        assert ev.venue_name == "High Noon Patio"
+        assert ev.venue_address is None
+
+    def test_show_only_time(self):
+        html = _FULL_CARD_HTML.replace(
+            "Doors: 7:00 pm | Show: 8:00 pm", "Show: 4:00 pm"
+        )
+        ev = _parse_card(_card(html))
+        assert ev is not None
+        assert ev.start_at == datetime(2026, 5, 7, 16, 0, tzinfo=_CENTRAL)
+        assert ev.all_day is False
+
+
+def test_zoneinfo_central_matches():
+    """Sanity check that the module's _CENTRAL is the expected zone."""
+    assert _CENTRAL == ZoneInfo("America/Chicago")

--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -89,8 +89,9 @@ Direct sources, generally worth their own scraper for completeness and richer da
 
 ### High Noon Saloon
 - URL: https://high-noon.com/calendar/
-- Scraper type prospect: html
-- Status: **investigating**
+- Scraper type: html
+- Status: **integrated**
+- Notes: Frank Productions / FPC Live property at 701 E. Washington Ave. WordPress site (custom post type `tm_event`, theme `fpc-main` from 45press.com). Calendar page renders ~60 upcoming shows in a single HTML response (~7-month forward window) as `article.event-card` elements with title, date ("May 7, 2026"), times ("Doors: 7:00 pm | Show: 8:00 pm" — Show preferred, Doors fallback), supporting acts, presented-by line, image, and `tm_classifications-*` taxonomy slugs as CSS classes. Single GET per scrape, no pagination (`/calendar/page/2/` returns the same page). robots.txt is fully open. Music genres map to `Music`; `arts-theatre` maps to `Theater & Stage`; `the-moth` / `use-your-noggin` / `nerd-nite` map to `Talks & Learning`. The source's `community-civic` slug is dropped — observed in practice as a catch-all (e.g. tagging student music showcases) rather than a clean civic-events category. WP REST API at `/wp-json/wp/v2/tm_event` was rejected: it exposes the post-publish timestamp under `date`, not the event date, and `acf` is empty.
 
 ### Majestic Theatre
 - URL: https://majesticmadison.com/

--- a/frontend/src/lib/sources.js
+++ b/frontend/src/lib/sources.js
@@ -1,4 +1,4 @@
-const SOURCE_PRIORITY = ['Isthmus', 'Visit Madison']
+const SOURCE_PRIORITY = ['High Noon Saloon', 'Isthmus', 'Visit Madison']
 
 export function sortedSources(sources) {
   if (!sources) return []


### PR DESCRIPTION
## Summary

Adds a direct scraper for High Noon Saloon (https://high-noon.com/calendar/), one of Madison's main independent music venues. Closes #77.

The scraper fetches the calendar page once and parses the rendered `article.event-card` markup — single GET, ~60 upcoming shows over a ~7-month forward window. The WordPress REST API at `/wp-json/wp/v2/tm_event` was rejected because its `date` field is the post-publish timestamp, not the event date, and `acf` is empty (no custom-field meta exposed).

- Adds `backend/app/scrapers/high_noon.py` (registered in `SCRAPERS`)
- Hardcodes the venue address so all events share one Nominatim cache row
- Maps the source's classification taxonomy conservatively: music genres → `Music`; `the-moth` / `use-your-noggin` / `nerd-nite` → `Talks & Learning`; `arts-theatre` → `Theater & Stage`. The `community-civic` slug is dropped — observed in practice as a catch-all (e.g. tagging student music showcases) rather than a clean civic-events category.
- Adds `'High Noon Saloon'` to `frontend/src/lib/sources.js` `SOURCE_PRIORITY` ahead of the aggregators so the venue-of-record wins the title-link role on cross-listed shows.
- Updates `docs/EVENT_SOURCES.md` (status investigating → integrated, plus rationale)
- Adds 30 new unit tests covering date parsing (incl. DST offsets), time extraction (Show preferred over Doors), classification mapping, and end-to-end card parsing

## Verification

- [x] `ruff check backend/` passes
- [x] `pytest backend/tests/` — 59 tests pass (29 existing + 30 new)
- [x] Standalone `HighNoonSource().fetch()` returns 60 events with correct date/time, venue, source URL, image, and category mappings
- [x] `POST /admin/scrape` against a fresh DB: High Noon Saloon → `{inserted: 51, updated: 7, deactivated: 0, geocoded: 51, geocode_misses: 0}` — the 7 "updated" are fuzzy cross-source matches with Isthmus / Visit Madison rows
- [x] DB inspection confirms 59 active High Noon source rows, all 59 distinct events geocoded (0 missing). Cross-listed events (e.g. Kylie Morgan, Madison StorySLAM) carry both `High Noon Saloon` and `Visit Madison` source rows with categories unioned.
- [x] DST sanity: events in May resolve to UTC-5 (CDT), events in December resolve to UTC-6 (CST)
- [x] Frontend: open a date with a High Noon show, confirm the card renders and links to the high-noon.com event page; switch to Map view and confirm a single pin at 701 E. Washington Ave with the show in its popup
- [x] If a show is cross-listed by Isthmus or Visit Madison, confirm the frontend shows one merged card with both sources in the footer

## Notes

- All 60 events in the current calendar are at the main "High Noon Saloon" venue — no Patio shows in the upcoming window. Address is hardcoded for that venue and left unset for any future "High Noon Patio" listings (those would still be name-geocoded).
- Event descriptions are short (presented-by + supporting acts, typically <80 chars), so the LLM tagger correctly skips them — categories come entirely from the source taxonomy mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)