### PR TITLE
Fix feedback form broken in production: use VITE_BACKEND_URL for /feedback fetch

### DIFF
--- a/frontend/src/components/FeedbackModal.jsx
+++ b/frontend/src/components/FeedbackModal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 
+const API_BASE = import.meta.env.VITE_BACKEND_URL || ''
 const GITHUB_REPO = 'linuxmaier/whats-up-madison'
 const GITHUB_ISSUES_URL = `https://github.com/${GITHUB_REPO}/issues/new`
 
@@ -44,7 +45,7 @@ export default function FeedbackModal({ open, onClose }) {
     e.preventDefault()
     setStatus('submitting')
     try {
-      const res = await fetch('/feedback', {
+      const res = await fetch(`${API_BASE}/feedback`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title, body, contact, website: honeypot }),


### PR DESCRIPTION
## Summary

- `FeedbackModal.jsx` was calling `fetch('/feedback', ...)` with a relative URL
- In the Vite dev server the proxy routes this to the backend; in production (Cloudflare Workers + Fly.io) there is no proxy — the POST hits Cloudflare's static asset handler and gets a 404
- `App.jsx` already uses `import.meta.env.VITE_BACKEND_URL` (set to `https://whats-up-madison.fly.dev` in Cloudflare's env vars) to prefix all API calls; applied the same pattern to `FeedbackModal.jsx`

closes #102

## Verification
- [x] Ruff lint passes
- [x] ESLint passes
- [x] Production build embeds the Fly.io URL: confirmed `fetch(\`${Jt}/feedback\`, ...)` in bundle where `Jt = 'https://whats-up-madison.fly.dev'`
- [ ] Open https://whatsupmadison.city, click "Submit feedback", fill in a title and details, and confirm submission succeeds without "Something went wrong"

🤖 Generated with [Claude Code](https://claude.com/claude-code)