### PR TITLE
Add Our Lives Wisconsin as event source (#101)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.routers import events
 from app.schemas import FeedbackRequest
 from app.scrapers.high_noon import HighNoonSource
 from app.scrapers.isthmus import IsthmusSource
+from app.scrapers.our_lives import OurLivesSource
 from app.scrapers.visit_madison import VisitMadisonSource
 from app.tagger import tag_untagged_events
 
@@ -69,7 +70,7 @@ app.add_middleware(
 
 app.include_router(events.router)
 
-SCRAPERS = [IsthmusSource(), VisitMadisonSource(), HighNoonSource()]
+SCRAPERS = [IsthmusSource(), VisitMadisonSource(), HighNoonSource(), OurLivesSource()]
 
 
 def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):

--- a/backend/app/scrapers/our_lives.py
+++ b/backend/app/scrapers/our_lives.py
@@ -1,0 +1,215 @@
+import logging
+import re
+import time
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from app.scrapers.base import BaseSource, RawEvent, clean_html_text, http_get_with_retry
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://ourliveswisconsin.com/wp-json/tribe/events/v1/events"
+_USER_AGENT = "whats-up-madison/0.1 (andrew.eric.maier@gmail.com)"
+_CENTRAL = ZoneInfo("America/Chicago")
+_WINDOW_DAYS = 30
+_PAGE_SIZE = 50
+_PAGE_SLEEP_SECONDS = 1.0
+
+# Madison metro: city + immediate Dane County suburbs that the broader app
+# already treats as "Madison". Outside this set we drop the event.
+_METRO_CITIES: frozenset[str] = frozenset({
+    "madison", "middleton", "verona", "sun prairie", "waunakee",
+    "fitchburg", "monona", "mcfarland", "stoughton",
+})
+_MADISON_ZIP_RE = re.compile(r"\b537\d{2}\b")
+
+# Conservative mapping from The Events Calendar (Tribe) taxonomy on Our Lives
+# to our closed taxonomy. Ambiguous, regional, audience-targeting, and one-off
+# tags are intentionally dropped so the LLM tagger (Step 4) can still enrich
+# them later if descriptions support it.
+_CATEGORY_MAP: dict[str, str] = {
+    "Music":           "Music",
+    "Comedy":          "Open Mic & Comedy",
+    "Dance":           "Dance",
+    "Theater":         "Theater & Stage",
+    "Performance Art": "Theater & Stage",
+    "Drag":            "Theater & Stage",
+    "Workshop":        "Talks & Learning",
+    "Lecture":         "Talks & Learning",
+    "Reading":         "Talks & Learning",
+    "Art Exhibition":  "Visual Art",
+    "Activism":        "Civic & Politics",
+    "Fundraiser":      "Volunteer & Causes",
+    "Sports":          "Sports & Recreation",
+    "Networking":      "Community & Clubs",
+    "Community":       "Community & Clubs",
+    "Outdoor":         "Outdoors & Nature",
+    "Food":            "Food & Drink",
+    "Market":          "Food & Drink",
+}
+
+
+class OurLivesSource(BaseSource):
+    name = "Our Lives"
+    scraper_type = "api"
+
+    def fetch(self) -> list[RawEvent]:
+        today = datetime.now(_CENTRAL).date()
+        end = today + timedelta(days=_WINDOW_DAYS)
+        events: list[RawEvent] = []
+        page = 1
+        while True:
+            params = {
+                "per_page": _PAGE_SIZE,
+                "page": page,
+                "start_date": today.isoformat(),
+                "end_date": end.isoformat(),
+            }
+            resp = http_get_with_retry(
+                _API_URL,
+                params=params,
+                headers={"User-Agent": _USER_AGENT},
+                timeout=30,
+            )
+            data = resp.json()
+            docs = data.get("events") or []
+            for doc in docs:
+                event = _parse_event(doc)
+                if event is not None:
+                    events.append(event)
+            total_pages = data.get("total_pages") or 1
+            if page >= total_pages or not docs:
+                break
+            page += 1
+            time.sleep(_PAGE_SLEEP_SECONDS)
+        return events
+
+
+def _venue_dict(raw) -> dict | None:
+    """Tribe returns venue as a dict, an empty list, or omits it. Normalize."""
+    if isinstance(raw, dict):
+        return raw or None
+    if isinstance(raw, list) and raw and isinstance(raw[0], dict):
+        return raw[0]
+    return None
+
+
+def _in_madison_metro(venue: dict | None) -> bool:
+    if not venue:
+        return False
+    city = (venue.get("city") or "").strip().lower()
+    if city in _METRO_CITIES:
+        return True
+    if city:
+        # Non-empty but not in allowlist — reject.
+        return False
+    # No city set: fall back to address-based heuristics for venues like the
+    # Overture Center that are unambiguously Madison but missing the field.
+    address = (venue.get("address") or "").lower()
+    if "madison" in address:
+        return True
+    if _MADISON_ZIP_RE.search(venue.get("zip") or ""):
+        return True
+    if _MADISON_ZIP_RE.search(address):
+        return True
+    return False
+
+
+def _parse_dt(raw: str | None, tz: ZoneInfo) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+    except ValueError:
+        return None
+
+
+def _build_address(venue: dict) -> str | None:
+    parts: list[str] = []
+    addr = (venue.get("address") or "").strip()
+    if addr:
+        parts.append(addr)
+    city = (venue.get("city") or "").strip()
+    if city:
+        parts.append(city)
+    state = (venue.get("state") or "").strip()
+    zipc = (venue.get("zip") or "").strip()
+    state_zip = " ".join(p for p in (state, zipc) if p).strip()
+    if state_zip:
+        parts.append(state_zip)
+    return ", ".join(parts) or None
+
+
+def _extract_image_url(image) -> str | None:
+    if isinstance(image, dict):
+        url = image.get("url")
+        if isinstance(url, str) and url:
+            return url
+    return None
+
+
+def _extract_categories(api_categories) -> list[str]:
+    if not isinstance(api_categories, list):
+        return []
+    seen: list[str] = []
+    for cat in api_categories:
+        if not isinstance(cat, dict):
+            continue
+        name = cat.get("name")
+        if not isinstance(name, str):
+            continue
+        mapped = _CATEGORY_MAP.get(name.strip())
+        if mapped and mapped not in seen:
+            seen.append(mapped)
+    return seen
+
+
+def _parse_event(doc: dict) -> RawEvent | None:
+    venue = _venue_dict(doc.get("venue"))
+    if not _in_madison_metro(venue):
+        return None
+
+    title = (doc.get("title") or "").strip()
+    source_url = (doc.get("url") or "").strip()
+    if not title or not source_url:
+        return None
+
+    tz_name = doc.get("timezone") or "America/Chicago"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = _CENTRAL
+
+    start_at = _parse_dt(doc.get("start_date"), tz)
+    if start_at is None:
+        logger.warning("Our Lives: unparseable start_date %r for %r",
+                       doc.get("start_date"), title)
+        return None
+
+    end_at = _parse_dt(doc.get("end_date"), tz)
+    all_day = bool(doc.get("all_day"))
+    if all_day:
+        # Tribe returns midnight-to-midnight for all-day; only keep an end_at
+        # if the event actually spans more than one day.
+        start_at = start_at.replace(hour=0, minute=0, second=0, microsecond=0)
+        if end_at is not None and end_at.date() == start_at.date():
+            end_at = None
+
+    description = clean_html_text(doc.get("description") or "") or None
+
+    venue_name = (venue.get("venue") or "").strip() or None
+    venue_address = _build_address(venue)
+
+    return RawEvent(
+        title=title,
+        start_at=start_at,
+        end_at=end_at,
+        venue_name=venue_name,
+        venue_address=venue_address,
+        description=description,
+        image_url=_extract_image_url(doc.get("image")),
+        categories=_extract_categories(doc.get("categories")),
+        all_day=all_day,
+        source_name="Our Lives",
+        source_url=source_url,
+    )

--- a/backend/tests/test_our_lives.py
+++ b/backend/tests/test_our_lives.py
@@ -1,0 +1,290 @@
+"""Unit tests for our_lives.py parsing helpers."""
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.scrapers.our_lives import (
+    _CENTRAL,
+    _build_address,
+    _extract_categories,
+    _extract_image_url,
+    _in_madison_metro,
+    _parse_event,
+    _venue_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# _venue_dict — Tribe sometimes ships venue as dict, sometimes [], sometimes missing
+# ---------------------------------------------------------------------------
+
+class TestVenueDict:
+    def test_dict_passthrough(self):
+        assert _venue_dict({"venue": "X"}) == {"venue": "X"}
+
+    def test_empty_list_returns_none(self):
+        assert _venue_dict([]) is None
+
+    def test_list_with_dict_returns_first(self):
+        assert _venue_dict([{"venue": "X"}]) == {"venue": "X"}
+
+    def test_none_returns_none(self):
+        assert _venue_dict(None) is None
+
+    def test_empty_dict_returns_none(self):
+        assert _venue_dict({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _in_madison_metro
+# ---------------------------------------------------------------------------
+
+class TestInMadisonMetro:
+    def test_madison_city_accepted(self):
+        assert _in_madison_metro({"city": "Madison"}) is True
+
+    def test_madison_case_insensitive(self):
+        assert _in_madison_metro({"city": "MADISON"}) is True
+        assert _in_madison_metro({"city": "  madison  "}) is True
+
+    def test_metro_suburbs_accepted(self):
+        for city in ("Middleton", "Verona", "Sun Prairie", "Waunakee",
+                     "Fitchburg", "Monona", "McFarland", "Stoughton"):
+            assert _in_madison_metro({"city": city}) is True, city
+
+    def test_outside_metro_rejected(self):
+        for city in ("Milwaukee", "Green Bay", "Stevens Point", "Aniwa", "Sheboygan"):
+            assert _in_madison_metro({"city": city}) is False, city
+
+    def test_no_venue_rejected(self):
+        assert _in_madison_metro(None) is False
+        assert _in_madison_metro({}) is False
+
+    def test_no_city_with_madison_address_accepted(self):
+        # Overture Center pattern — city missing but address is Madison.
+        assert _in_madison_metro({"address": "201 State Street, Madison, WI"}) is True
+
+    def test_no_city_with_madison_zip_accepted(self):
+        assert _in_madison_metro({"address": "1 Capitol Sq", "zip": "53703"}) is True
+
+    def test_no_city_with_zip_in_address_accepted(self):
+        assert _in_madison_metro({"address": "100 Main St 53715"}) is True
+
+    def test_no_city_no_madison_signal_rejected(self):
+        # No city, address doesn't match Madison.
+        assert _in_madison_metro({"address": "123 Anywhere St"}) is False
+        assert _in_madison_metro({"address": ""}) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_address
+# ---------------------------------------------------------------------------
+
+class TestBuildAddress:
+    def test_full_address(self):
+        venue = {"address": "300 Richard St", "city": "Verona", "state": "WI", "zip": "53593"}
+        assert _build_address(venue) == "300 Richard St, Verona, WI 53593"
+
+    def test_missing_zip(self):
+        venue = {"address": "201 State Street", "city": "Madison", "state": "WI"}
+        assert _build_address(venue) == "201 State Street, Madison, WI"
+
+    def test_missing_state_and_zip(self):
+        venue = {"address": "100 Main St", "city": "Madison"}
+        assert _build_address(venue) == "100 Main St, Madison"
+
+    def test_only_address(self):
+        assert _build_address({"address": "201 State Street"}) == "201 State Street"
+
+    def test_empty_returns_none(self):
+        assert _build_address({}) is None
+        assert _build_address({"address": "", "city": ""}) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_image_url
+# ---------------------------------------------------------------------------
+
+class TestExtractImageUrl:
+    def test_dict_with_url(self):
+        assert _extract_image_url({"url": "https://x/y.jpg"}) == "https://x/y.jpg"
+
+    def test_dict_without_url(self):
+        assert _extract_image_url({"sizes": {}}) is None
+
+    def test_empty_list(self):
+        assert _extract_image_url([]) is None
+
+    def test_none(self):
+        assert _extract_image_url(None) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_categories
+# ---------------------------------------------------------------------------
+
+class TestExtractCategories:
+    def test_known_tags_mapped(self):
+        cats = [{"name": "Music"}, {"name": "Comedy"}]
+        assert _extract_categories(cats) == ["Music", "Open Mic & Comedy"]
+
+    def test_drag_maps_to_theater(self):
+        assert _extract_categories([{"name": "Drag"}]) == ["Theater & Stage"]
+
+    def test_collapses_duplicates_after_mapping(self):
+        # Theater + Performance Art + Drag all map to "Theater & Stage" —
+        # output should dedup while preserving first-seen order.
+        cats = [{"name": "Theater"}, {"name": "Performance Art"}, {"name": "Drag"}]
+        assert _extract_categories(cats) == ["Theater & Stage"]
+
+    def test_dropped_tags_silently_ignored(self):
+        cats = [
+            {"name": "Social"},
+            {"name": "Madison + South Central"},
+            {"name": "21+"},
+            {"name": "Festival"},
+            {"name": "Music"},
+        ]
+        assert _extract_categories(cats) == ["Music"]
+
+    def test_unknown_tag_dropped(self):
+        assert _extract_categories([{"name": "MysteryGenre"}]) == []
+
+    def test_non_list_returns_empty(self):
+        assert _extract_categories(None) == []
+        assert _extract_categories("Music") == []
+
+    def test_malformed_entries_skipped(self):
+        cats = [{"name": "Music"}, "not a dict", {"missing": "name"}, {"name": None}]
+        assert _extract_categories(cats) == ["Music"]
+
+
+# ---------------------------------------------------------------------------
+# _parse_event (integration with helpers above)
+# ---------------------------------------------------------------------------
+
+def _base_doc(**overrides) -> dict:
+    """Minimal shape matching a real Tribe events API response."""
+    doc = {
+        "title": "Euchre Night",
+        "url": "https://ourliveswisconsin.com/event/euchre-night/2026-05-08/",
+        "description": "<p>Join us in the taproom for some good old fashioned Euchre!</p>",
+        "start_date": "2026-05-08 18:30:00",
+        "end_date": "2026-05-08 21:30:00",
+        "all_day": False,
+        "timezone": "America/Chicago",
+        "image": {"url": "https://x/poster.png"},
+        "categories": [{"name": "Community"}, {"name": "Social"}],
+        "venue": {
+            "venue": "Delta Beer Lab",
+            "address": "167 E Badger Rd",
+            "city": "Madison",
+            "state": "WI",
+            "zip": "53713",
+        },
+    }
+    doc.update(overrides)
+    return doc
+
+
+class TestParseEvent:
+    def test_full_event(self):
+        ev = _parse_event(_base_doc())
+        assert ev is not None
+        assert ev.title == "Euchre Night"
+        assert ev.start_at == datetime(2026, 5, 8, 18, 30, tzinfo=_CENTRAL)
+        assert ev.end_at == datetime(2026, 5, 8, 21, 30, tzinfo=_CENTRAL)
+        assert ev.all_day is False
+        assert ev.venue_name == "Delta Beer Lab"
+        assert ev.venue_address == "167 E Badger Rd, Madison, WI 53713"
+        assert ev.description == "Join us in the taproom for some good old fashioned Euchre!"
+        assert ev.image_url == "https://x/poster.png"
+        # Community → Community & Clubs; Social is dropped.
+        assert ev.categories == ["Community & Clubs"]
+        assert ev.source_name == "Our Lives"
+        assert ev.source_url == "https://ourliveswisconsin.com/event/euchre-night/2026-05-08/"
+
+    def test_outside_metro_returns_none(self):
+        ev = _parse_event(_base_doc(venue={
+            "venue": "South Second",
+            "address": "838 South 2nd Street",
+            "city": "Milwaukee",
+            "state": "WI",
+            "zip": "53204",
+        }))
+        assert ev is None
+
+    def test_no_venue_returns_none(self):
+        assert _parse_event(_base_doc(venue=[])) is None
+        assert _parse_event(_base_doc(venue=None)) is None
+
+    def test_overture_no_city_accepted(self):
+        # Real-world: Overture Center venue has address but no city. Should
+        # be accepted by the address-based fallback.
+        ev = _parse_event(_base_doc(venue={
+            "venue": "Overture Center – Promenade Hall",
+            "address": "201 State Street, Madison",
+        }))
+        assert ev is not None
+        assert ev.venue_name == "Overture Center – Promenade Hall"
+
+    def test_all_day_event(self):
+        ev = _parse_event(_base_doc(
+            all_day=True,
+            start_date="2026-05-08 00:00:00",
+            end_date="2026-05-08 23:59:59",
+        ))
+        assert ev is not None
+        assert ev.all_day is True
+        assert ev.start_at == datetime(2026, 5, 8, 0, 0, tzinfo=_CENTRAL)
+        # Same-day end_at on an all-day event is dropped.
+        assert ev.end_at is None
+
+    def test_multi_day_all_day_keeps_end(self):
+        ev = _parse_event(_base_doc(
+            all_day=True,
+            start_date="2026-05-08 00:00:00",
+            end_date="2026-05-10 23:59:59",
+        ))
+        assert ev is not None
+        assert ev.all_day is True
+        assert ev.end_at == datetime(2026, 5, 10, 23, 59, 59, tzinfo=_CENTRAL)
+
+    def test_multi_day_timed_event_keeps_end(self):
+        # LGBTQ Spring CampOUT pattern — runs across multiple days.
+        ev = _parse_event(_base_doc(
+            start_date="2026-05-28 12:00:00",
+            end_date="2026-05-31 17:00:00",
+        ))
+        assert ev is not None
+        assert ev.start_at.date() != ev.end_at.date()
+
+    def test_missing_image_yields_none(self):
+        ev = _parse_event(_base_doc(image=[]))
+        assert ev is not None
+        assert ev.image_url is None
+
+    def test_missing_title_returns_none(self):
+        assert _parse_event(_base_doc(title="")) is None
+
+    def test_missing_url_returns_none(self):
+        assert _parse_event(_base_doc(url="")) is None
+
+    def test_invalid_start_date_returns_none(self):
+        assert _parse_event(_base_doc(start_date="not a date")) is None
+
+    def test_html_entities_in_title_preserved(self):
+        # Title arrives as the API-decoded value; we don't double-decode.
+        # Description is the only HTML we clean.
+        ev = _parse_event(_base_doc(title="National Women's Music Festival"))
+        assert ev is not None
+        assert ev.title == "National Women's Music Festival"
+
+    def test_unusual_timezone_falls_back_to_central(self):
+        ev = _parse_event(_base_doc(timezone="Not/A_Zone"))
+        assert ev is not None
+        # Still parses; falls back to America/Chicago.
+        assert ev.start_at.tzinfo is not None
+
+
+def test_central_zone_constant():
+    assert _CENTRAL == ZoneInfo("America/Chicago")

--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -33,6 +33,12 @@ These cover many venues and event types from a single source. Highest leverage i
 - Status: **integrated**
 - Notes: Official tourism CVB site, curated and lower-noise than Isthmus. Uses the Simpleview DMS events JSON API at `/includes/rest_v2/plugins_events_events_by_date/find/`. Public `apiToken` is hardcoded in the events page HTML and extracted on each run (with a hardcoded fallback in case extraction fails). Paginated at `limit=30` due to a 200 KB server-side response cap; ~460 events in a 30-day window means ~15-16 sequential requests per run, throttled at 0.5 s between pages. Maps Simpleview's category taxonomy to our taxonomy where unambiguous; ambiguous and non-content categories (Annual Events, Arts & Culture, Entertainment & Nightlife, Fairs & Festivals, Free Event, Holiday/Seasonal, Shopping, Virtual Event) are dropped and left for the LLM tagging pass.
 
+### Our Lives
+- URL: https://ourliveswisconsin.com/events/
+- Scraper type: api
+- Status: **integrated**
+- Notes: Wisconsin's LGBTQ community magazine and event hub. WordPress site running The Events Calendar (Tribe) plugin; uses the public REST endpoint `/wp-json/tribe/events/v1/events` (no auth). 30-day forward window, paginated `per_page=50` (~3 pages, ~120 events statewide). The feed covers all of Wisconsin, so the scraper applies a city allowlist filter to keep only Madison-metro events: Madison, Middleton, Verona, Sun Prairie, Waunakee, Fitchburg, Monona, McFarland, Stoughton. Venues with no `city` field (e.g. Overture Center) are accepted when the address contains "madison" or a 537xx ZIP. Tribe taxonomy maps conservatively to ours (`Music`, `Comedy`, `Dance`, `Theater`/`Performance Art`/`Drag` → `Theater & Stage`, `Workshop`/`Lecture`/`Reading` → `Talks & Learning`, `Activism` → `Civic & Politics`, `Fundraiser` → `Volunteer & Causes`, etc.); ambiguous tags (`Social`, `Festival`, `Pride`, `Party`), regional tags (`Madison + South Central`, etc.), and audience-targeting tags (`21+`, `All Ages`) are dropped so the LLM tagger handles them. Recurring events arrive as separate occurrences with date-stamped URLs (e.g. `/event/euchre-night/2026-05-08/`), so no RRULE expansion is needed. Polite 1s delay between pages.
+
 ### Eventbrite
 - URL: https://www.eventbrite.com/d/wi--madison/events/
 - Scraper type prospect: api

--- a/frontend/src/lib/sources.js
+++ b/frontend/src/lib/sources.js
@@ -1,4 +1,4 @@
-const SOURCE_PRIORITY = ['High Noon Saloon', 'Isthmus', 'Visit Madison']
+const SOURCE_PRIORITY = ['High Noon Saloon', 'Our Lives', 'Isthmus', 'Visit Madison']
 
 export function sortedSources(sources) {
   if (!sources) return []


### PR DESCRIPTION
## Summary
- Adds `OurLivesSource` scraper for ourliveswisconsin.com (Wisconsin LGBTQ event hub) using The Events Calendar (Tribe) public REST API.
- Filters statewide feed to Madison metro by venue city (Madison + immediate Dane County suburbs); falls back to address/ZIP for venues missing the city field.
- Maps Tribe categories conservatively into our taxonomy; drops ambiguous / regional / audience-targeting tags so the LLM tagger handles them.
- Registers the source in `SCRAPERS`, `SOURCE_PRIORITY`, and the `EVENT_SOURCES.md` catalog.

## Verification
- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/` — 103 passed (44 new in `test_our_lives.py`)
- [x] Live scraper smoke test — 43 events fetched, all in Madison-metro cities, all `venue_address` populated
- [x] End-to-end ingest via `POST /admin/scrape` — 35 inserted, 22 geocoded, 2 dedup-merged onto Visit Madison events (multi-source `sources[]` confirmed)
- [x] `GET /events?date=2026-05-09` — Our Lives entries appear with correct `source_url`
- [x] Open http://localhost:5173, pick a date with Our Lives events, confirm cards render and the source link points back to ourliveswisconsin.com
- [x] Switch to map view and confirm the new pins render at plausible Madison-area locations

closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)