### PR TITLE
Fix Isthmus scraper crash on empty RSS page body

### DIFF
--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -77,6 +77,8 @@ def _build_url_map(
     page = 1
     while True:
         resp = http_get_with_retry(_RSS_BASE, params={"page": page}, timeout=30)
+        if not resp.content.strip():
+            break
         root = ET.fromstring(resp.content)
         items = root.findall(".//item")
         if not items:


### PR DESCRIPTION
## Summary

- Isthmus RSS pagination was crashing with `no element found: line 1, column 0` because page 40 of their feed returns HTTP 200 with an empty body
- `ET.fromstring(b"")` raises a `ParseError` rather than returning gracefully, aborting the entire Isthmus scrape run
- Added an empty-body check before parsing — treats an empty response as end-of-feed, consistent with how the no-items case is already handled

## Test plan

- [x] Trigger `POST /admin/scrape` and confirm Isthmus returns inserted/updated counts rather than an error key
- [x] Verify Isthmus events appear in the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)