### PR TITLE
Fix slow first load on production: pre-warm Fly backend from index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Discover events happening in Madison, WI" />
     <title>What's Up Madison</title>
+    <script>
+      // Pre-warm the backend so its cold start (Fly auto-stop) overlaps with
+      // the JS bundle download instead of blocking the first /events fetch.
+      (function () {
+        var backend = "%VITE_BACKEND_URL%";
+        if (backend && /^https?:/.test(backend)) {
+          var link = document.createElement('link');
+          link.rel = 'preconnect';
+          link.href = backend;
+          link.crossOrigin = '';
+          document.head.appendChild(link);
+          fetch(backend + '/health').catch(function () {});
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Issue #99: production first load took ~4-5s because Fly.io is configured with `auto_stop_machines='stop'` and `min_machines_running=0`, so the machine sleeps when idle and the first user request waits for it to wake. Measured `/health` cold start at **4.67s** vs **60-260ms** warm.
- Fix: a small inline script in `frontend/index.html` fires `GET %VITE_BACKEND_URL%/health` (Vite substitutes the URL at build time) and adds a `<link rel="preconnect">` to the backend origin, all before the JS bundle script tag. The Fly wake now overlaps with bundle download + React mount, so by the time the app fires its first `/events` fetch, the backend is (mostly) already awake. No infrastructure / cost change.
- Guarded with `/^https?:/.test(backend)` so dev mode (where `VITE_BACKEND_URL` is unset and Vite leaves the literal `%VITE_BACKEND_URL%`) is a no-op and never hits the dev proxy.

## Verification

- [x] `npm run build` with `VITE_BACKEND_URL=https://whats-up-madison.fly.dev` produces `dist/index.html` with the URL correctly substituted into the prefetch script
- [x] `npm run build` with `VITE_BACKEND_URL` unset leaves the literal `%VITE_BACKEND_URL%` placeholder; the regex guard prevents any rogue fetch in that case
- [x] `ruff check backend/` passes (no backend changes, baseline confirmed)
- [ ] After deploy: wait long enough for Fly to auto-stop (>5 min idle), then visit the site in a fresh tab. Browser dev-tools → Network panel should show `/health` firing well before `/events`, with the two overlapping. Page should feel noticeably faster than before.
- [ ] Confirm no console errors related to the inline pre-warm script.

closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)