### PR TITLE
Add Ticketmaster Discovery API scraper for Madison venues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ React + Vite + Tailwind CSS. Node deps are project-local (not in conda).
 
 ### Source priority
 
-`frontend/src/lib/sources.js` exports `sortedSources(sources)`, which sorts a `sources` array by `SOURCE_PRIORITY` (currently `['Isthmus', 'Visit Madison']`). Both card components use this to determine the title link (first source wins) and footer display order. When adding a new scraper, add it to `SOURCE_PRIORITY` at the appropriate trust rank; sources not in the list sort to the end.
+`frontend/src/lib/sources.js` exports `sortedSources(sources)`, which sorts a `sources` array by `SOURCE_PRIORITY` (a hand-ordered list of integrated scraper names). Both card components use this to determine the title link (first source wins) and footer display order. When adding a new scraper, add it to `SOURCE_PRIORITY` at the appropriate trust rank; sources not in the list sort to the end.
 
 ### Card types
 
@@ -198,7 +198,7 @@ To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost
 - **Done (Step 4):** closed category taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source's own taxonomy; LLM-assisted tagging pass shipped in `backend/app/tagger.py` (runs at end of `/admin/scrape`, also exposed as `/admin/tag`); category filter UI in frontend (multi-select tag cloud, sensible defaults, persists to localStorage).
 - **Done (Step 5):** geocoding pipeline (Nominatim, cached per venue in `venue_geocodes`) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve.
 - **Done (recent polish):** fuzzy cross-source dedup in ingest (title similarity ≥ 0.65 anchored by time + venue); explicit source priority ranking (`SOURCE_PRIORITY` in `frontend/src/lib/sources.js`); Isthmus description enrichment from event detail pages; Previous/Next nav buttons; sticky-header layout fixes.
-- **In progress (Step 3):** Isthmus integrated (iCal + RSS, 30-day window, ~235 events) and Visit Madison integrated (Simpleview JSON API, 30-day window, ~460 events); more sources in `docs/EVENT_SOURCES.md`; daily scheduling not yet wired up (no APScheduler — recommend running `/admin/scrape` from cron / systemd timer / external scheduler).
+- **In progress (Step 3):** five scrapers integrated — Isthmus (iCal + RSS), Visit Madison (Simpleview JSON API), High Noon Saloon (HTML calendar), Our Lives (Tribe Events REST), and Ticketmaster (Discovery API, multi-venue: Sylvee, Majestic, Orpheum, Overture, Kohl Center, etc.). All but High Noon use a 30-day forward window. More candidate sources in `docs/EVENT_SOURCES.md`; daily scheduling not yet wired up (no APScheduler — recommend running `/admin/scrape` from cron / systemd timer / external scheduler).
 
 Backend: http://localhost:8000 — API docs: http://localhost:8000/docs
 Frontend: http://localhost:5173

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,7 @@ TAGGER_MODEL=claude-haiku-4-5
 ADMIN_API_KEY=your-admin-key-here
 # GitHub PAT with issues:write scope — used by POST /feedback to file user-submitted issues
 GITHUB_TOKEN=your-github-pat-here
+# Ticketmaster Discovery API key — used by the Ticketmaster scraper to pull events for Madison-area
+# Ticketmaster-ticketed venues (The Sylvee, Majestic, Orpheum, Overture, Kohl Center, etc.). Get one
+# at https://developer-acct.ticketmaster.com/. If unset the Ticketmaster scraper raises ValueError.
+TICKETMASTER_API_KEY=your-key-here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     admin_api_key: str = ""
     github_token: str = ""
     github_repo: str = "linuxmaier/whats-up-madison"
+    ticketmaster_api_key: str = ""
 
     @model_validator(mode="after")
     def check_production_admin_key(self):

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -161,7 +161,16 @@ def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
     best: "Event | None" = None
     best_ratio = 0.0
     for event in candidates:
-        ratio = SequenceMatcher(None, raw_title, event.title.lower().strip()).ratio()
+        cand_title = event.title.lower().strip()
+        ratio = SequenceMatcher(None, raw_title, cand_title).ratio()
+        # When one title is fully contained in the other (e.g. "Pert Near
+        # Sandstone" vs "Pert Near Sandstone-Side by Side Album Release …"),
+        # treat it as a match. SequenceMatcher's ratio drops well below the
+        # threshold for prefix/extension cases like this even though it's
+        # clearly the same event. Safe because we already require an exact
+        # start_at + venue_name anchor.
+        if raw_title and cand_title and (raw_title in cand_title or cand_title in raw_title):
+            ratio = max(ratio, 1.0)
         if ratio > best_ratio:
             best_ratio, best = ratio, event
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.schemas import FeedbackRequest
 from app.scrapers.high_noon import HighNoonSource
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.our_lives import OurLivesSource
+from app.scrapers.ticketmaster import TicketmasterSource
 from app.scrapers.visit_madison import VisitMadisonSource
 from app.tagger import tag_untagged_events
 
@@ -70,7 +71,7 @@ app.add_middleware(
 
 app.include_router(events.router)
 
-SCRAPERS = [IsthmusSource(), VisitMadisonSource(), HighNoonSource(), OurLivesSource()]
+SCRAPERS = [IsthmusSource(), VisitMadisonSource(), HighNoonSource(), OurLivesSource(), TicketmasterSource()]
 
 
 def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):

--- a/backend/app/scrapers/ticketmaster.py
+++ b/backend/app/scrapers/ticketmaster.py
@@ -1,0 +1,217 @@
+import logging
+import time
+from datetime import date, datetime, time as dtime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.config import settings
+from app.scrapers.base import BaseSource, RawEvent, http_get_with_retry
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://app.ticketmaster.com/discovery/v2/events.json"
+_USER_AGENT = "whats-up-madison/0.1 (andrew.eric.maier@gmail.com)"
+_CENTRAL = ZoneInfo("America/Chicago")
+_WINDOW_DAYS = 30
+_PAGE_SIZE = 200  # Discovery API max
+_PAGE_SLEEP_SECONDS = 0.25  # well under the 5 req/s rate limit
+_DROP_STATUSES: frozenset[str] = frozenset({"cancelled", "postponed"})
+
+# Conservative segment/genre → our taxonomy mapping. Lookup order is
+# (segment, genre) first, then (segment, None). Anything unmapped is dropped
+# so the LLM tagging pass can enrich from description.
+_CATEGORY_MAP: dict[tuple[str, str | None], str] = {
+    ("Music", None):                            "Music",
+    ("Arts & Theatre", "Comedy"):               "Open Mic & Comedy",
+    ("Arts & Theatre", "Theatre"):              "Theater & Stage",
+    ("Arts & Theatre", "Children's Theatre"):   "Theater & Stage",
+    ("Arts & Theatre", "Performance Art"):      "Theater & Stage",
+    ("Arts & Theatre", "Dance"):                "Theater & Stage",
+    ("Sports", None):                           "Sports & Recreation",
+    ("Family", None):                           "Family & Kids",
+}
+
+
+class TicketmasterSource(BaseSource):
+    name = "Ticketmaster"
+    scraper_type = "api"
+
+    def fetch(self) -> list[RawEvent]:
+        if not settings.ticketmaster_api_key:
+            raise ValueError("TICKETMASTER_API_KEY is not set")
+
+        today = datetime.now(_CENTRAL).date()
+        end = today + timedelta(days=_WINDOW_DAYS)
+        start_iso = _utc_iso_z(datetime.combine(today, dtime.min, tzinfo=_CENTRAL))
+        end_iso = _utc_iso_z(datetime.combine(end, dtime.max, tzinfo=_CENTRAL))
+
+        events: list[RawEvent] = []
+        page = 0
+        while True:
+            params = {
+                "apikey": settings.ticketmaster_api_key,
+                "city": "Madison",
+                "stateCode": "WI",
+                "countryCode": "US",
+                "startDateTime": start_iso,
+                "endDateTime": end_iso,
+                "size": _PAGE_SIZE,
+                "page": page,
+                "sort": "date,asc",
+            }
+            resp = http_get_with_retry(
+                _API_URL,
+                params=params,
+                headers={"User-Agent": _USER_AGENT},
+                timeout=30,
+            )
+            data = resp.json()
+            docs = (data.get("_embedded") or {}).get("events") or []
+            for doc in docs:
+                event = _parse_event(doc)
+                if event is not None:
+                    events.append(event)
+            total_pages = (data.get("page") or {}).get("totalPages") or 1
+            if not docs or page + 1 >= total_pages:
+                break
+            page += 1
+            time.sleep(_PAGE_SLEEP_SECONDS)
+
+        return events
+
+
+def _utc_iso_z(dt: datetime) -> str:
+    """Convert an aware datetime to ``YYYY-MM-DDTHH:MM:SSZ`` (Discovery API format)."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_local_date(raw: str | None) -> date | None:
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _parse_local_time(raw: str | None) -> dtime | None:
+    if not raw:
+        return None
+    try:
+        return dtime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _build_address(venue: dict) -> str | None:
+    line1 = ((venue.get("address") or {}).get("line1") or "").strip()
+    city = ((venue.get("city") or {}).get("name") or "").strip()
+    state = ((venue.get("state") or {}).get("stateCode") or "").strip()
+    zipc = (venue.get("postalCode") or "").strip()
+    parts: list[str] = []
+    if line1:
+        parts.append(line1)
+    if city:
+        parts.append(city)
+    state_zip = " ".join(p for p in (state, zipc) if p).strip()
+    if state_zip:
+        parts.append(state_zip)
+    return ", ".join(parts) or None
+
+
+def _select_image(images: list[dict]) -> str | None:
+    """Pick the largest 16:9 image; fall back to the first usable URL."""
+    best: dict | None = None
+    for img in images or []:
+        if not isinstance(img, dict) or not img.get("url"):
+            continue
+        if img.get("ratio") == "16_9":
+            if best is None or (img.get("width") or 0) > (best.get("width") or 0):
+                best = img
+    if best is not None:
+        return best.get("url")
+    for img in images or []:
+        if isinstance(img, dict) and img.get("url"):
+            return img["url"]
+    return None
+
+
+def _map_categories(classifications: list[dict]) -> list[str]:
+    if not classifications:
+        return []
+    primary = next(
+        (c for c in classifications if isinstance(c, dict) and c.get("primary")),
+        None,
+    )
+    if primary is None:
+        return []
+    seg = ((primary.get("segment") or {}).get("name") or "").strip() or None
+    gen = ((primary.get("genre") or {}).get("name") or "").strip() or None
+    if seg is None:
+        return []
+    mapped = _CATEGORY_MAP.get((seg, gen)) or _CATEGORY_MAP.get((seg, None))
+    return [mapped] if mapped else []
+
+
+def _parse_event(doc: dict) -> RawEvent | None:
+    dates = doc.get("dates") or {}
+    status = ((dates.get("status") or {}).get("code") or "").strip().lower()
+    if status in _DROP_STATUSES:
+        return None
+
+    title = (doc.get("name") or "").strip()
+    source_url = (doc.get("url") or "").strip()
+    if not title or not source_url:
+        return None
+
+    venues = (doc.get("_embedded") or {}).get("venues") or []
+    venue = venues[0] if venues else None
+    if not isinstance(venue, dict):
+        return None
+
+    start_block = dates.get("start") or {}
+    event_date = _parse_local_date(start_block.get("localDate"))
+    if event_date is None:
+        return None
+
+    tz_name = dates.get("timezone") or "America/Chicago"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        tz = _CENTRAL
+
+    local_time = _parse_local_time(start_block.get("localTime"))
+    time_tba = bool(start_block.get("timeTBA")) or bool(start_block.get("noSpecificTime"))
+    if local_time is None or time_tba:
+        start_at = datetime.combine(event_date, dtime.min, tzinfo=tz)
+        all_day = True
+    else:
+        start_at = datetime.combine(event_date, local_time, tzinfo=tz)
+        all_day = False
+
+    end_at: datetime | None = None
+    end_block = dates.get("end") or {}
+    end_date = _parse_local_date(end_block.get("localDate"))
+    if dates.get("spanMultipleDays") and end_date is not None:
+        end_time = _parse_local_time(end_block.get("localTime")) or dtime.max
+        end_at = datetime.combine(end_date, end_time, tzinfo=tz)
+
+    description = (doc.get("info") or doc.get("pleaseNote") or "").strip() or None
+
+    venue_name = (venue.get("name") or "").strip() or None
+    venue_address = _build_address(venue)
+    image_url = _select_image(doc.get("images") or [])
+    categories = _map_categories(doc.get("classifications") or [])
+
+    return RawEvent(
+        title=title,
+        start_at=start_at,
+        end_at=end_at,
+        venue_name=venue_name,
+        venue_address=venue_address,
+        description=description,
+        image_url=image_url,
+        categories=categories,
+        all_day=all_day,
+        source_name="Ticketmaster",
+        source_url=source_url,
+    )

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -103,6 +103,56 @@ def test_fuzzy_match_merges(db):
 
 
 # ---------------------------------------------------------------------------
+# 4b. Substring titles merge even when SequenceMatcher ratio is low
+# ---------------------------------------------------------------------------
+
+def test_substring_title_merges(db):
+    # Real-world case: High Noon ("Pert Near Sandstone") and Ticketmaster
+    # ("Pert Near Sandstone-Side by Side Album Release & Road to Blue Ox Tour")
+    # for the same show. SequenceMatcher.ratio is ~0.40 because the longer
+    # title is much longer, but with identical start_at + venue_name the two
+    # rows are clearly the same event and should be merged.
+    short_title = "Pert Near Sandstone"
+    long_title = "Pert Near Sandstone-Side by Side Album Release & Road to Blue Ox Tour"
+
+    ingest_events("Source A", [_raw(title=short_title, source_name="Source A")], db)
+    ingest_events(
+        "Source B",
+        [_raw(title=long_title, source_name="Source B", source_url="https://b.example/2")],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+    # Reverse direction: long title first, short title second — also merges.
+    db.query(EventSource).delete()
+    db.query(Event).delete()
+    db.commit()
+    ingest_events("Source B", [_raw(title=long_title, source_name="Source B")], db)
+    ingest_events(
+        "Source A",
+        [_raw(title=short_title, source_name="Source A", source_url="https://a.example/3")],
+        db,
+    )
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+
+def test_unrelated_titles_do_not_merge_via_substring(db):
+    # Sanity check: two different events at the same time + venue must stay
+    # separate even though no title contains the other. (e.g. distinct
+    # support acts in opening slots are uncommon, but defensive coverage.)
+    ingest_events("Source A", [_raw(title="Concert in the Park", source_name="Source A")], db)
+    ingest_events(
+        "Source B",
+        [_raw(title="Totally Different Event", source_name="Source B", source_url="https://b.example/4")],
+        db,
+    )
+    assert db.query(Event).count() == 2
+
+
+# ---------------------------------------------------------------------------
 # 5. Staleness: event removed from a run → EventSource inactive, Event removed
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_ticketmaster.py
+++ b/backend/tests/test_ticketmaster.py
@@ -1,0 +1,334 @@
+"""Unit tests for ticketmaster.py parsing helpers."""
+from datetime import datetime, time as dtime
+from zoneinfo import ZoneInfo
+
+from app.scrapers.ticketmaster import (
+    _CENTRAL,
+    _build_address,
+    _map_categories,
+    _parse_event,
+    _select_image,
+)
+
+
+def _venue(line1="25 S. Livingston Street", city="Madison", state="WI", zipc="53703"):
+    out: dict = {"name": "The Sylvee"}
+    if line1 is not None:
+        out["address"] = {"line1": line1}
+    if city is not None:
+        out["city"] = {"name": city}
+    if state is not None:
+        out["state"] = {"stateCode": state}
+    if zipc is not None:
+        out["postalCode"] = zipc
+    return out
+
+
+def _doc(
+    *,
+    name="Modest Mouse",
+    url="https://www.ticketmaster.com/modest-mouse/event/abc",
+    local_date="2026-09-29",
+    local_time="20:00:00",
+    span_multi_days=False,
+    end_date=None,
+    end_time=None,
+    status="onsale",
+    timezone="America/Chicago",
+    info="Doors at 6:30 pm | Show at 8:00 pm. Cashless venue, bag policy applies.",
+    please_note=None,
+    venue=None,
+    images=None,
+    classifications=None,
+    time_tba=False,
+    no_specific_time=False,
+):
+    if venue is None:
+        venue = _venue()
+    start: dict = {"localDate": local_date}
+    if local_time is not None:
+        start["localTime"] = local_time
+    if time_tba:
+        start["timeTBA"] = True
+    if no_specific_time:
+        start["noSpecificTime"] = True
+    dates: dict = {
+        "start": start,
+        "timezone": timezone,
+        "spanMultipleDays": span_multi_days,
+        "status": {"code": status},
+    }
+    if end_date or end_time:
+        end: dict = {}
+        if end_date:
+            end["localDate"] = end_date
+        if end_time:
+            end["localTime"] = end_time
+        dates["end"] = end
+    doc: dict = {
+        "name": name,
+        "url": url,
+        "dates": dates,
+        "_embedded": {"venues": [venue]},
+    }
+    if info is not None:
+        doc["info"] = info
+    if please_note is not None:
+        doc["pleaseNote"] = please_note
+    if images is not None:
+        doc["images"] = images
+    if classifications is not None:
+        doc["classifications"] = classifications
+    return doc
+
+
+def _cls(segment, genre=None, primary=True):
+    out: dict = {"primary": primary, "segment": {"name": segment}}
+    if genre is not None:
+        out["genre"] = {"name": genre}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# _build_address
+# ---------------------------------------------------------------------------
+
+class TestBuildAddress:
+    def test_full_address(self):
+        assert _build_address(_venue()) == "25 S. Livingston Street, Madison, WI 53703"
+
+    def test_missing_zip(self):
+        assert _build_address(_venue(zipc="")) == "25 S. Livingston Street, Madison, WI"
+
+    def test_missing_city(self):
+        assert _build_address(_venue(city="")) == "25 S. Livingston Street, WI 53703"
+
+    def test_missing_state(self):
+        assert _build_address(_venue(state="")) == "25 S. Livingston Street, Madison, 53703"
+
+    def test_only_line1(self):
+        v = {"address": {"line1": "100 Main St"}}
+        assert _build_address(v) == "100 Main St"
+
+    def test_empty_returns_none(self):
+        assert _build_address({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _select_image
+# ---------------------------------------------------------------------------
+
+class TestSelectImage:
+    def test_picks_largest_16_9(self):
+        images = [
+            {"ratio": "16_9", "url": "small.jpg", "width": 205},
+            {"ratio": "16_9", "url": "large.jpg", "width": 1136},
+            {"ratio": "3_2", "url": "wrong-ratio.jpg", "width": 2000},
+        ]
+        assert _select_image(images) == "large.jpg"
+
+    def test_falls_back_to_first_when_no_16_9(self):
+        images = [
+            {"ratio": "3_2", "url": "fallback.jpg", "width": 305},
+        ]
+        assert _select_image(images) == "fallback.jpg"
+
+    def test_skips_entries_without_url(self):
+        images = [
+            {"ratio": "16_9", "width": 1136},  # no url
+            {"ratio": "16_9", "url": "ok.jpg", "width": 640},
+        ]
+        assert _select_image(images) == "ok.jpg"
+
+    def test_empty(self):
+        assert _select_image([]) is None
+
+
+# ---------------------------------------------------------------------------
+# _map_categories
+# ---------------------------------------------------------------------------
+
+class TestMapCategories:
+    def test_music_rock_to_music(self):
+        assert _map_categories([_cls("Music", "Rock")]) == ["Music"]
+
+    def test_music_jazz_to_music(self):
+        assert _map_categories([_cls("Music", "Jazz")]) == ["Music"]
+
+    def test_music_no_genre_to_music(self):
+        assert _map_categories([_cls("Music")]) == ["Music"]
+
+    def test_arts_theatre_comedy_to_open_mic_and_comedy(self):
+        assert _map_categories([_cls("Arts & Theatre", "Comedy")]) == ["Open Mic & Comedy"]
+
+    def test_arts_theatre_theatre_to_theater_and_stage(self):
+        assert _map_categories([_cls("Arts & Theatre", "Theatre")]) == ["Theater & Stage"]
+
+    def test_arts_theatre_childrens_to_theater_and_stage(self):
+        assert _map_categories([_cls("Arts & Theatre", "Children's Theatre")]) == ["Theater & Stage"]
+
+    def test_arts_theatre_dance_to_theater_and_stage(self):
+        # TM "Dance" under Arts & Theatre is ballet/contemporary performance, not
+        # social dance — keep it under Theater & Stage to match our taxonomy intent.
+        assert _map_categories([_cls("Arts & Theatre", "Dance")]) == ["Theater & Stage"]
+
+    def test_sports_football_to_sports_and_recreation(self):
+        assert _map_categories([_cls("Sports", "Football")]) == ["Sports & Recreation"]
+
+    def test_family_to_family_and_kids(self):
+        assert _map_categories([_cls("Family", "Children's Music")]) == ["Family & Kids"]
+
+    def test_arts_theatre_miscellaneous_dropped(self):
+        assert _map_categories([_cls("Arts & Theatre", "Miscellaneous")]) == []
+
+    def test_undefined_segment_dropped(self):
+        assert _map_categories([_cls("Undefined")]) == []
+
+    def test_miscellaneous_segment_dropped(self):
+        assert _map_categories([_cls("Miscellaneous", "Undefined")]) == []
+
+    def test_non_primary_classification_ignored(self):
+        # Only the primary classification is consulted.
+        non_primary = _cls("Music", "Rock", primary=False)
+        secondary = _cls("Sports", "Football", primary=True)
+        assert _map_categories([non_primary, secondary]) == ["Sports & Recreation"]
+
+    def test_no_primary_returns_empty(self):
+        non_primary = _cls("Music", "Rock", primary=False)
+        assert _map_categories([non_primary]) == []
+
+    def test_empty(self):
+        assert _map_categories([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_event
+# ---------------------------------------------------------------------------
+
+class TestParseEvent:
+    def test_full_happy_path(self):
+        ev = _parse_event(_doc(
+            classifications=[_cls("Music", "Rock")],
+            images=[
+                {"ratio": "16_9", "url": "https://img/large.jpg", "width": 1136},
+                {"ratio": "3_2", "url": "https://img/wrong.jpg", "width": 2000},
+            ],
+        ))
+        assert ev is not None
+        assert ev.title == "Modest Mouse"
+        assert ev.start_at == datetime(2026, 9, 29, 20, 0, tzinfo=ZoneInfo("America/Chicago"))
+        assert ev.end_at is None
+        assert ev.all_day is False
+        assert ev.venue_name == "The Sylvee"
+        assert ev.venue_address == "25 S. Livingston Street, Madison, WI 53703"
+        assert ev.description.startswith("Doors at 6:30 pm")
+        assert ev.image_url == "https://img/large.jpg"
+        assert ev.categories == ["Music"]
+        assert ev.source_name == "Ticketmaster"
+        assert ev.source_url == "https://www.ticketmaster.com/modest-mouse/event/abc"
+
+    def test_cancelled_returns_none(self):
+        assert _parse_event(_doc(status="cancelled")) is None
+
+    def test_postponed_returns_none(self):
+        assert _parse_event(_doc(status="postponed")) is None
+
+    def test_offsale_status_kept(self):
+        # offsale just means tickets aren't on sale at the moment; event is still happening.
+        assert _parse_event(_doc(status="offsale")) is not None
+
+    def test_rescheduled_status_kept(self):
+        assert _parse_event(_doc(status="rescheduled")) is not None
+
+    def test_missing_local_time_falls_back_to_all_day(self):
+        ev = _parse_event(_doc(local_time=None))
+        assert ev is not None
+        assert ev.all_day is True
+        assert ev.start_at == datetime(2026, 9, 29, 0, 0, tzinfo=ZoneInfo("America/Chicago"))
+
+    def test_time_tba_treated_as_all_day(self):
+        ev = _parse_event(_doc(local_time="20:00:00", time_tba=True))
+        assert ev is not None
+        assert ev.all_day is True
+
+    def test_no_specific_time_treated_as_all_day(self):
+        ev = _parse_event(_doc(local_time="20:00:00", no_specific_time=True))
+        assert ev is not None
+        assert ev.all_day is True
+
+    def test_span_multi_days_populates_end_at(self):
+        ev = _parse_event(_doc(
+            local_date="2026-09-29",
+            local_time="10:00:00",
+            span_multi_days=True,
+            end_date="2026-10-01",
+            end_time="22:00:00",
+        ))
+        assert ev is not None
+        assert ev.start_at == datetime(2026, 9, 29, 10, 0, tzinfo=ZoneInfo("America/Chicago"))
+        assert ev.end_at == datetime(2026, 10, 1, 22, 0, tzinfo=ZoneInfo("America/Chicago"))
+
+    def test_single_day_span_ignored(self):
+        # spanMultipleDays=False even with end block → end_at should be None.
+        ev = _parse_event(_doc(
+            span_multi_days=False,
+            end_date="2026-09-29",
+            end_time="23:00:00",
+        ))
+        assert ev is not None
+        assert ev.end_at is None
+
+    def test_missing_local_date_returns_none(self):
+        assert _parse_event(_doc(local_date=None)) is None
+
+    def test_missing_title_returns_none(self):
+        assert _parse_event(_doc(name="")) is None
+
+    def test_missing_url_returns_none(self):
+        assert _parse_event(_doc(url="")) is None
+
+    def test_missing_venue_returns_none(self):
+        doc = _doc()
+        doc["_embedded"] = {"venues": []}
+        assert _parse_event(doc) is None
+
+    def test_description_falls_back_to_please_note(self):
+        ev = _parse_event(_doc(info=None, please_note="Bag policy in effect."))
+        assert ev is not None
+        assert ev.description == "Bag policy in effect."
+
+    def test_description_none_when_both_missing(self):
+        ev = _parse_event(_doc(info=None, please_note=None))
+        assert ev is not None
+        assert ev.description is None
+
+    def test_zoneinfo_central_matches(self):
+        # Sanity check that the module uses the expected zone.
+        assert _CENTRAL == ZoneInfo("America/Chicago")
+        # And that the parser uses the timezone field from dates.
+        ev = _parse_event(_doc(timezone="America/Chicago"))
+        assert ev.start_at.tzinfo is not None
+        assert ev.start_at.utcoffset() in {
+            ZoneInfo("America/Chicago").utcoffset(datetime(2026, 9, 29, 20, 0)),
+        }
+
+    def test_dst_summer_offset(self):
+        # July → CDT (UTC-5)
+        ev = _parse_event(_doc(local_date="2026-07-04", local_time="20:00:00"))
+        assert ev.start_at.utcoffset().total_seconds() == -5 * 3600
+
+    def test_dst_winter_offset(self):
+        # December → CST (UTC-6)
+        ev = _parse_event(_doc(local_date="2026-12-15", local_time="20:00:00"))
+        assert ev.start_at.utcoffset().total_seconds() == -6 * 3600
+
+    def test_end_at_defaults_to_end_of_day_when_end_time_missing(self):
+        ev = _parse_event(_doc(
+            span_multi_days=True,
+            end_date="2026-10-01",
+            end_time=None,
+        ))
+        assert ev is not None
+        assert ev.end_at is not None
+        assert ev.end_at.date().isoformat() == "2026-10-01"
+        assert ev.end_at.time() == dtime.max

--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -33,6 +33,12 @@ These cover many venues and event types from a single source. Highest leverage i
 - Status: **integrated**
 - Notes: Official tourism CVB site, curated and lower-noise than Isthmus. Uses the Simpleview DMS events JSON API at `/includes/rest_v2/plugins_events_events_by_date/find/`. Public `apiToken` is hardcoded in the events page HTML and extracted on each run (with a hardcoded fallback in case extraction fails). Paginated at `limit=30` due to a 200 KB server-side response cap; ~460 events in a 30-day window means ~15-16 sequential requests per run, throttled at 0.5 s between pages. Maps Simpleview's category taxonomy to our taxonomy where unambiguous; ambiguous and non-content categories (Annual Events, Arts & Culture, Entertainment & Nightlife, Fairs & Festivals, Free Event, Holiday/Seasonal, Shopping, Virtual Event) are dropped and left for the LLM tagging pass.
 
+### Ticketmaster
+- URL: https://app.ticketmaster.com/discovery/v2/events.json
+- Scraper type: api (Ticketmaster Discovery API)
+- Status: **integrated**
+- Notes: Multi-venue Madison aggregator. A single GET to `/discovery/v2/events.json?city=Madison&stateCode=WI&countryCode=US` (with `startDateTime`/`endDateTime` bounding a 30-day forward window) covers every Madison venue that sells tickets through Ticketmaster — The Sylvee, Majestic Theatre, Orpheum, Barrymore, Overture Center (and its sub-rooms), Kohl Center, Camp Randall, Breese Stevens, Roxxy, etc. Paginated `size=200` (~2 pages, ~250 events). Auth via `apikey=` query param (the `TICKETMASTER_API_KEY` setting); rate limit is 5 req/s and 5000/day so we sleep 0.25 s between pages. Events with `dates.status.code` in {`cancelled`, `postponed`} are dropped; `onsale`/`offsale`/`rescheduled` are kept. Time parsing uses `dates.start.{localDate,localTime}` + `dates.timezone`; missing `localTime` or `timeTBA=true` falls back to all-day. `spanMultipleDays=true` populates `end_at`. Description from `info` (preferred) or `pleaseNote`; both are plain text so no HTML cleaning needed. Classifications map conservatively: `Music/*` → `Music`; `Arts & Theatre / Comedy` → `Open Mic & Comedy`; `Arts & Theatre / Theatre|Children's Theatre|Performance Art|Dance` → `Theater & Stage`; `Sports/*` → `Sports & Recreation`; `Family/*` → `Family & Kids`. `Arts & Theatre / Miscellaneous` and `Undefined`/`Miscellaneous` segments are dropped so the LLM tagger handles them. The same event sometimes appears multiple times (e.g. distinct listings for affiliate sales channels like the UW Badgers store) — `canonical_hash` collapses these. Events that overlap with the dedicated High Noon Saloon scraper land on the same `Event` row via fuzzy dedup, with both `EventSource` rows kept; the High Noon URL wins for the title link via `SOURCE_PRIORITY`.
+
 ### Our Lives
 - URL: https://ourliveswisconsin.com/events/
 - Scraper type: api
@@ -101,14 +107,15 @@ Direct sources, generally worth their own scraper for completeness and richer da
 
 ### Majestic Theatre
 - URL: https://majesticmadison.com/
-- Scraper type prospect: html
-- Status: **investigating**
+- Scraper type: api (Ticketmaster Discovery API)
+- Status: **integrated**
+- Notes: Covered by the **Ticketmaster** aggregator scraper above (Discovery API venue ID `KovZpZAaltvA`, ~33 upcoming events at integration time). No standalone Majestic scraper needed. The Majestic's own site (majesticmadison.com) was not separately scraped — Ticketmaster is the authoritative ticket-sales URL, and `SOURCE_PRIORITY` already routes title links there for Majestic events.
 
 ### The Sylvee (Frank Productions)
 - URL: https://www.ticketmaster.com/the-sylvee-tickets-madison/venue/237554
-- Scraper type prospect: api (Ticketmaster Discovery API)
-- Status: **investigating**
-- Notes: Tickets sold via Ticketmaster — could pull this and other Ticketmaster venues at once.
+- Scraper type: api (Ticketmaster Discovery API)
+- Status: **integrated**
+- Notes: Covered by the **Ticketmaster** aggregator scraper above (Discovery API venue ID `KovZ917AQBC`, ~30 upcoming events at integration time). The Sylvee shares Frank Productions ownership with High Noon Saloon, but unlike High Noon (which has its own calendar page) The Sylvee's only public events surface is Ticketmaster.
 
 ### Atwood Music Hall
 - URL: https://www.theatwoodmusichall.com/shows

--- a/frontend/src/lib/sources.js
+++ b/frontend/src/lib/sources.js
@@ -1,4 +1,4 @@
-const SOURCE_PRIORITY = ['High Noon Saloon', 'Our Lives', 'Isthmus', 'Visit Madison']
+const SOURCE_PRIORITY = ['High Noon Saloon', 'Ticketmaster', 'Our Lives', 'Isthmus', 'Visit Madison']
 
 export function sortedSources(sources) {
   if (!sources) return []


### PR DESCRIPTION
Closes #79

## Summary

- New `TicketmasterSource` scraper in `backend/app/scrapers/ticketmaster.py` using the public Discovery API. A single query (`city=Madison&stateCode=WI&countryCode=US`) over a 30-day forward window covers The Sylvee, Majestic Theatre, Overture Center (and sub-rooms), Orpheum, Barrymore, Kohl Center, Camp Randall, Breese Stevens, Roxxy, and any other Madison venue that sells tickets through Ticketmaster — no per-venue scraper needed.
- Conservative category mapping from Ticketmaster's segment/genre taxonomy (Music/* → Music; Arts & Theatre / Comedy → Open Mic & Comedy; Arts & Theatre / Theatre|Children's Theatre|Performance Art|Dance → Theater & Stage; Sports/* → Sports & Recreation; Family/* → Family & Kids). Ambiguous classifications fall through to the existing LLM tagger.
- Status filtering drops `cancelled` and `postponed` events; `onsale`/`offsale`/`rescheduled` are kept. Time-TBA events fall back to all-day; `spanMultipleDays=true` populates `end_at`. Description prefers `info` and falls back to `pleaseNote`.
- `'Ticketmaster'` slots into `SOURCE_PRIORITY` between `'High Noon Saloon'` and `'Our Lives'` so when an event is listed by both High Noon's own site and Ticketmaster, the venue's direct page wins the title link.
- **Fuzzy dedup hardening (caught during verification):** `backend/app/ingest.py:_fuzzy_find_event` now also treats title-substring containment as a match. Real-world case: "Pert Near Sandstone" (HN/VM) vs "Pert Near Sandstone-Side by Side Album Release & Road to Blue Ox Tour" (TM) at the same venue + start_at had a SequenceMatcher ratio of ~0.40 (below the 0.65 threshold) and was producing two separate Event rows. With this change the three sources now merge into a single Event with three EventSource rows. Anchor (exact start_at + venue_name) makes substring matching safe.

## Out of scope (filed separately)

A pre-existing geocoding mismatch where Visit Madison delivers `"701A E Washington Ave"` for High Noon Saloon and Nominatim resolves it a few blocks east of the actual venue. Surfaced by this PR's side-by-side comparison with Ticketmaster's correctly-geotagged listings, but the bug exists on `main` independent of this change. Tracked as #115.

## Test plan
- [x] `ruff check backend/` clean
- [x] `pytest backend/tests/` — full suite green (150 passed: 45 new fixture-based tests in `test_ticketmaster.py`, 2 new in `test_ingest.py` for substring dedup, plus all existing)
- [x] `docker compose up -d` — backend boots cleanly with the scraper registered
- [x] First `POST /admin/scrape` (pre-fix) — Ticketmaster: `{inserted: 32, updated: 2, geocoded: 32, geocode_misses: 0}`
- [x] Second `POST /admin/scrape` (post-dedup-fix, fresh DB) — Ticketmaster: `{inserted: 27, updated: 4, geocoded: 27, geocode_misses: 0}`. The 5-event reduction is exactly the substring-merge case: TM events whose titles extend HN/VM titles (or vice versa) now collapse into one Event row instead of duplicating
- [x] DB spot-check — TM events spread across 8 Madison venues (Sylvee, Majestic, Orpheum, Overture + sub-rooms, Barrymore, Kohl Center, High Noon)
- [x] `GET /events?date=…` — sample TM events (Black Veil Brides @ Sylvee 2026-05-23, myspace nite @ Majestic 2026-05-23) return with correct `latitude`/`longitude` and `Ticketmaster` in `sources[]`
- [x] Cross-source dedup verified — "Pert Near Sandstone" merged into a single Event row with three EventSource entries (High Noon Saloon, Ticketmaster, Visit Madison) after the fix
- [x] Open http://localhost:5173, navigate to a date with a known TM event, confirm cards render with Ticketmaster source link in the footer and that titles for TM-only events click through to ticketmaster.com
- [x] Switch to Map view; confirm TM-only events (e.g. Sylvee shows) appear as pins at the correct address. Note: events at venues that go through Visit Madison's malformed-address pipeline will be a few blocks off — that's #115, not this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)