### PR TITLE
Fix major Madison venues geotagged blocks off when ingested via Visit Madison (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,15 @@ After each scraper runs inside `POST /admin/scrape`, a geocoding pass populates 
 
 Scrapers don't need to do anything special — populating `RawEvent.venue_address` (preferred) or `RawEvent.venue_name` is enough for the geocoder to attempt a lookup.
 
+#### Canonical venue registry (`backend/app/canonical_venues.py`)
+
+A small allowlist of well-known Madison venues (High Noon Saloon, The Sylvee, Majestic, Orpheum, Barrymore, Overture Center) maps `venue_name` → known-good `(latitude, longitude, address)`. Two consumers use it:
+
+- `geocode_event` consults the registry **before** the cache or Nominatim — short-circuits the network call entirely, immune to upstream address quirks, and corrects already-bad coordinates on the next geocode pass.
+- `ingest_events` overwrites `Event.venue_address` with the canonical address when `venue_name` matches, regardless of `_FILLABLE_FIELDS` semantics. This was added because Visit Madison sometimes ships malformed addresses (e.g. `701A E Washington Ave` for High Noon) that snap to wrong coordinates and clutter the displayed address card.
+
+To add a venue: lowercase the name as it appears in `Event.venue_name`, curl Nominatim with the canonical address to get verified coordinates, then add an entry. Add alt spellings (e.g. "orpheum theater" vs "orpheum theatre") as separate keys — matching is exact after lowercase + trim.
+
 ### Tagging (`backend/app/tagger.py`)
 
 `tag_untagged_events(db, model=None)` runs the LLM category-tagging pass. It selects active events whose `categories` array is empty (i.e., the source didn't pre-tag them) and whose `description` is at least 80 characters, batches them 25 at a time, and asks Claude to assign zero or more tags from `CATEGORIES`. The system prompt is sent with `cache_control: ephemeral` so repeated batches reuse the prompt cache. Predictions outside the taxonomy are silently dropped. Each batch commits independently, so a mid-run failure leaves prior batches persisted.

--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -1,0 +1,71 @@
+"""Hard-coded coordinates and addresses for well-known Madison venues.
+
+When a scraper ships a slightly malformed address (e.g. Visit Madison's
+"701A E Washington Ave" for High Noon Saloon), Nominatim snaps to the wrong
+spot — sometimes blocks away. This registry short-circuits both the
+geocoder and the ingest address-fill logic for venues we know by name, so
+the displayed address and pin are correct regardless of upstream variance.
+
+Coordinates are verified against Nominatim using the canonical address
+listed here. To add a venue: pick the name as it appears in
+``Event.venue_name`` (lowercase), curl Nominatim with the correct address,
+paste the lat/lon into a new entry. Add alt spellings as separate keys.
+"""
+
+from typing import NamedTuple, Optional
+
+
+class CanonicalVenue(NamedTuple):
+    latitude: float
+    longitude: float
+    address: str
+
+
+CANONICAL_VENUES: dict[str, CanonicalVenue] = {
+    "high noon saloon": CanonicalVenue(
+        43.0797191, -89.3762962, "701 E Washington Ave, Madison, WI 53703"
+    ),
+    "the sylvee": CanonicalVenue(
+        43.0808002, -89.3746711, "25 S Livingston St, Madison, WI 53703"
+    ),
+    "majestic theatre": CanonicalVenue(
+        43.0744156, -89.3808963, "115 King St, Madison, WI 53703"
+    ),
+    "orpheum theater": CanonicalVenue(
+        43.0751848, -89.3887320, "216 State St, Madison, WI 53703"
+    ),
+    "orpheum theatre": CanonicalVenue(
+        43.0751848, -89.3887320, "216 State St, Madison, WI 53703"
+    ),
+    "barrymore theatre": CanonicalVenue(
+        43.0930640, -89.3522665, "2090 Atwood Ave, Madison, WI 53704"
+    ),
+    "overture center": CanonicalVenue(
+        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
+    ),
+    "overture center for the arts": CanonicalVenue(
+        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
+    ),
+}
+
+
+def _normalize(venue_name: Optional[str]) -> Optional[str]:
+    if not venue_name:
+        return None
+    return venue_name.strip().lower()
+
+
+def lookup(venue_name: Optional[str]) -> Optional[CanonicalVenue]:
+    """Return the canonical entry for ``venue_name``, or None.
+
+    Matching is case-insensitive and ignores leading/trailing whitespace.
+    """
+    key = _normalize(venue_name)
+    if key is None:
+        return None
+    return CANONICAL_VENUES.get(key)
+
+
+def canonical_keys() -> list[str]:
+    """Lowercased venue-name keys, useful for SQL ``IN`` filters."""
+    return list(CANONICAL_VENUES.keys())

--- a/backend/app/geocode_runner.py
+++ b/backend/app/geocode_runner.py
@@ -1,9 +1,10 @@
 import logging
 import time
 
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
+from app import canonical_venues
 from app.geocoding import geocode_event
 from app.models import Event, EventSource, VenueGeocode
 
@@ -11,12 +12,20 @@ logger = logging.getLogger(__name__)
 
 
 def _missing_coords_query(db: Session):
+    # Canonical-venue events are always included so wrong coords cached by an
+    # earlier ingest get re-checked and corrected against the registry on the
+    # next pass (see #115). geocode_event is a no-op when coords already match,
+    # so the extra rows are cheap.
+    canonical_names = canonical_venues.canonical_keys()
     return (
         db.query(Event)
         .filter(
             Event.status == "active",
-            Event.latitude.is_(None),
             or_(Event.venue_address.isnot(None), Event.venue_name.isnot(None)),
+            or_(
+                Event.latitude.is_(None),
+                func.lower(func.trim(Event.venue_name)).in_(canonical_names),
+            ),
         )
     )
 

--- a/backend/app/geocoding.py
+++ b/backend/app/geocoding.py
@@ -7,6 +7,7 @@ from typing import Optional
 import httpx
 from sqlalchemy.orm import Session
 
+from app import canonical_venues
 from app.models import Event, VenueGeocode
 
 logger = logging.getLogger(__name__)
@@ -125,7 +126,19 @@ def geocode_lookup(lookup_key: str, db: Session) -> Optional[tuple[float, float]
 
 
 def geocode_event(event: Event, db: Session) -> bool:
-    """Set event.latitude/longitude from cache or Nominatim. Returns True on hit."""
+    """Set event.latitude/longitude from canonical registry, cache, or Nominatim.
+
+    Returns True if coordinates were changed. Canonical registry hits short-
+    circuit ahead of any cache or network lookup so listed venues are immune
+    to upstream address malformations (see #115).
+    """
+    canonical = canonical_venues.lookup(event.venue_name)
+    if canonical is not None:
+        if event.latitude == canonical.latitude and event.longitude == canonical.longitude:
+            return False
+        event.latitude = canonical.latitude
+        event.longitude = canonical.longitude
+        return True
     if event.latitude is not None and event.longitude is not None:
         return False
     key = normalize_lookup(event.venue_name, event.venue_address)

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -6,6 +6,7 @@ from sqlalchemy import cast, func, select
 from sqlalchemy import Date as SQLDate
 from sqlalchemy.orm import Session
 
+from app import canonical_venues
 from app.models import Event, EventSource
 from app.scrapers.base import RawEvent
 
@@ -81,6 +82,12 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
                 changed = True
             if changed:
                 updated += 1
+
+        # Overwrite venue_address with the canonical value when this venue is
+        # in the registry, regardless of fill-in-nulls semantics — the whole
+        # point is that aggregator addresses for these venues are unreliable
+        # (#115). Skipped when the venue isn't a known canonical match.
+        _apply_canonical_address(event)
 
         if event.id not in seen_for_source:
             source = (
@@ -180,6 +187,14 @@ def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
         )
         return best
     return None
+
+
+def _apply_canonical_address(event: Event) -> None:
+    canonical = canonical_venues.lookup(event.venue_name)
+    if canonical is None:
+        return
+    if event.venue_address != canonical.address:
+        event.venue_address = canonical.address
 
 
 def _dedupe_by_hash(raw_events: list[RawEvent]) -> list[RawEvent]:

--- a/backend/tests/test_geocoding.py
+++ b/backend/tests/test_geocoding.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app import canonical_venues
+from app.geocoding import geocode_event
+from app.models import Event
+
+
+def _event(**overrides) -> Event:
+    base = dict(
+        title="Pert Near Sandstone",
+        start_at=datetime(2026, 5, 15, 20, 0, tzinfo=timezone.utc),
+        venue_name="High Noon Saloon",
+        canonical_hash="hash-1",
+        status="active",
+    )
+    base.update(overrides)
+    return Event(**base)
+
+
+def test_canonical_lookup_normalizes_case_and_whitespace():
+    assert canonical_venues.lookup("HIGH NOON SALOON") is not None
+    assert canonical_venues.lookup("  high noon saloon  ") is not None
+    assert canonical_venues.lookup("Random Coffee Shop") is None
+    assert canonical_venues.lookup(None) is None
+    assert canonical_venues.lookup("") is None
+
+
+def test_canonical_venue_overrides_existing_bad_coords(db, monkeypatch):
+    # Reproduces #115: an Event row carrying the wrong High Noon coords from
+    # Visit Madison's malformed address. Without the fix, geocode_event
+    # early-exits because latitude is set, leaving the bad coords in place.
+    event = _event(
+        venue_address="701A E Washington Ave, Madison, WI 53703",
+        latitude=43.0849,
+        longitude=-89.3699,
+    )
+    db.add(event)
+    db.commit()
+
+    def boom(*args, **kwargs):
+        raise AssertionError("Nominatim should not be called for canonical venues")
+
+    monkeypatch.setattr("app.geocoding._call_nominatim", boom)
+
+    updated = geocode_event(event, db)
+
+    assert updated is True
+    canonical = canonical_venues.lookup("High Noon Saloon")
+    assert event.latitude == canonical.latitude
+    assert event.longitude == canonical.longitude
+
+
+def test_canonical_venue_skips_nominatim_when_already_correct(db, monkeypatch):
+    canonical = canonical_venues.lookup("High Noon Saloon")
+    event = _event(
+        canonical_hash="hash-2",
+        latitude=canonical.latitude,
+        longitude=canonical.longitude,
+    )
+    db.add(event)
+    db.commit()
+
+    monkeypatch.setattr(
+        "app.geocoding._call_nominatim",
+        lambda *a, **k: pytest.fail("Nominatim called for already-correct canonical venue"),
+    )
+
+    assert geocode_event(event, db) is False
+
+
+def test_canonical_venue_with_no_coords_uses_registry_not_nominatim(db, monkeypatch):
+    event = _event(canonical_hash="hash-3")  # latitude/longitude default to None
+    db.add(event)
+    db.commit()
+
+    monkeypatch.setattr(
+        "app.geocoding._call_nominatim",
+        lambda *a, **k: pytest.fail("Nominatim called for canonical venue with no coords"),
+    )
+
+    assert geocode_event(event, db) is True
+    canonical = canonical_venues.lookup("High Noon Saloon")
+    assert (event.latitude, event.longitude) == (canonical.latitude, canonical.longitude)
+
+
+def test_non_canonical_venue_falls_through_to_nominatim_path(db, monkeypatch):
+    event = _event(
+        canonical_hash="hash-4",
+        venue_name="Some Random Bar",
+        venue_address="999 Fake Street, Madison, WI",
+    )
+    db.add(event)
+    db.commit()
+
+    calls: list[str] = []
+
+    def fake_lookup(_key, _db):
+        calls.append("lookup")
+        return (43.0, -89.4)
+
+    monkeypatch.setattr("app.geocoding.geocode_lookup", fake_lookup)
+
+    assert geocode_event(event, db) is True
+    assert calls == ["lookup"]
+    assert event.latitude == 43.0
+    assert event.longitude == -89.4

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -207,3 +207,61 @@ def test_pre_dedup_collapses_same_hash(db):
 
     event = db.query(Event).one()
     assert set(event.categories) == {"community", "food"}
+
+
+# ---------------------------------------------------------------------------
+# 8. Canonical-venue address override (#115): a malformed address from an
+#    aggregator is replaced with the canonical address regardless of fill-in-
+#    nulls semantics, so the displayed address card and the geocoder both see
+#    the clean string.
+# ---------------------------------------------------------------------------
+
+def test_canonical_venue_address_overrides_malformed_input_on_insert(db):
+    bad = _raw(
+        title="Pert Near Sandstone",
+        venue_name="High Noon Saloon",
+        venue_address="701A E Washington Ave, Madison, WI 53703",
+        source_name="Visit Madison",
+    )
+
+    ingest_events("Visit Madison", [bad], db)
+
+    event = db.query(Event).one()
+    assert event.venue_address == "701 E Washington Ave, Madison, WI 53703"
+
+
+def test_canonical_venue_address_corrected_on_subsequent_run(db):
+    bad = _raw(
+        title="Pert Near Sandstone",
+        venue_name="High Noon Saloon",
+        venue_address="701A E Washington Ave, Madison, WI 53703",
+        source_name="Source A",
+    )
+    ingest_events("Source A", [bad], db)
+    event = db.query(Event).one()
+    assert event.venue_address == "701 E Washington Ave, Madison, WI 53703"
+
+    # A second source confirming the same event keeps the canonical value
+    # rather than falling back to its own address (also possibly off).
+    other = _raw(
+        title="Pert Near Sandstone",
+        venue_name="High Noon Saloon",
+        venue_address="701 East Washington Avenue, Madison, WI 53703",
+        source_name="Source B",
+        source_url="https://b.example/1",
+    )
+    ingest_events("Source B", [other], db)
+
+    db.refresh(event)
+    assert event.venue_address == "701 E Washington Ave, Madison, WI 53703"
+
+
+def test_non_canonical_venue_address_is_left_untouched(db):
+    raw = _raw(
+        venue_name="Some Random Bar",
+        venue_address="999 Fake Street, Madison, WI",
+    )
+    ingest_events("Source A", [raw], db)
+
+    event = db.query(Event).one()
+    assert event.venue_address == "999 Fake Street, Madison, WI"


### PR DESCRIPTION
## Summary
- Adds a canonical-venue registry (`backend/app/canonical_venues.py`) for High Noon Saloon, The Sylvee, Majestic, Orpheum, Barrymore, and Overture Center — verified coords + canonical address strings.
- `geocode_event` consults the registry **before** the cache or Nominatim, so listed venues skip the network entirely and back-correct already-bad coordinates on the next geocode pass.
- `ingest_events` overrides `Event.venue_address` with the canonical value when `venue_name` matches, regardless of `_FILLABLE_FIELDS` semantics — fixes the displayed address card too, not just the map pin.
- `geocode_runner._missing_coords_query` now also picks up canonical-venue events that already have (wrong) coords, so the next scheduled scrape will silently correct them.

## Verification
- [x] `ruff check backend/` — clean.
- [x] `pytest backend/tests/` — 158 tests pass, including 5 new in `test_geocoding.py` and 3 new in `test_ingest.py`.
- [x] Live: seeded a synthetic Event row with the malformed `701A E Washington Ave` address and the wrong coords from the issue (`43.0849, -89.3699`); `POST /admin/geocode` corrected coords to canonical `43.0797191, -89.3762962` in 0.0s (no Nominatim call).
- [x] Live: ran `ingest_events("Visit Madison", [<raw with bad address>], db)` directly — the resulting Event row's `venue_address` was rewritten to the canonical `701 E Washington Ave, Madison, WI 53703`.
- [x] AGENTS.md updated with a Canonical venue registry subsection under Geocoding.
- [ ] After next production scrape, visually confirm the High Noon pin sits at 701 E Washington Ave on the Map view (rather than ~3 blocks east) and that the displayed address card reads `701 E Washington Ave, Madison, WI 53703`.
- [ ] Spot-check the other 5 registered venues (Sylvee, Majestic, Orpheum, Barrymore, Overture) on the production map after the next scrape.

## Notes
- The stale `701a e washington ave, madison, wi 53703` row in `venue_geocodes` is harmless — the canonical short-circuit happens before `geocode_lookup`, so it's never consulted again. Can be dropped in a one-line cleanup if desired.
- Coordinates in the registry were verified by querying Nominatim with each venue's canonical address (the same path Nominatim already takes for clean inputs).

closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)