### PR TITLE
Prefer highest-trust source fields for multi-source events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ All scrapers share `ingest_events(source_name, raw_events, db)`. It handles:
 - **Pre-dedup** — collapses multiple raws sharing a `canonical_hash` from the same run before insert (a source can return e.g. two recurring "Volunteer at Foodbank" series with different IDs but identical title/date/venue); categories are unioned across the duplicates
 - **Upsert** by `canonical_hash` — inserts new events, skips exact duplicates
 - **Fuzzy dedup** — after an exact hash miss, a secondary search matches candidates by time+venue and scores title similarity via `difflib.SequenceMatcher`; events scoring ≥ `FUZZY_TITLE_THRESHOLD` (0.65) are treated as duplicates and merged rather than inserted as new rows; this catches near-identical events listed under slightly different titles by different sources
-- **Fill-in-nulls** — adds missing scalar fields from later sources; never overwrites set values
+- **Source-priority merge** — when a later source has higher trust rank (per `SOURCE_PRIORITY` in `ingest.py`, mirroring the frontend list), it overwrites all non-null `_OVERWRITABLE_FIELDS` (title, description, end_at, venue_name, venue_address, image_url); equal- or lower-priority sources only fill null fields
 - **Category union** — `RawEvent.categories` are merged into `Event.categories` preserving order, no duplicates; later sources can enrich an earlier one
 - **Multi-source** — one `EventSource` row per (event, source); same event from two scrapers gets two `EventSource` rows, both linked to the same `Event`
 - **Staleness** — after each run, deactivates `EventSource` rows from that scraper not seen in the run; marks `Event.status = 'removed'` when no active sources remain
@@ -132,7 +132,7 @@ Scrapers don't need to do anything special — populating `RawEvent.venue_addres
 A small allowlist of well-known Madison venues (High Noon Saloon, The Sylvee, Majestic, Orpheum, Barrymore, Overture Center) maps `venue_name` → known-good `(latitude, longitude, address)`. Two consumers use it:
 
 - `geocode_event` consults the registry **before** the cache or Nominatim — short-circuits the network call entirely, immune to upstream address quirks, and corrects already-bad coordinates on the next geocode pass.
-- `ingest_events` overwrites `Event.venue_address` with the canonical address when `venue_name` matches, regardless of `_FILLABLE_FIELDS` semantics. This was added because Visit Madison sometimes ships malformed addresses (e.g. `701A E Washington Ave` for High Noon) that snap to wrong coordinates and clutter the displayed address card.
+- `ingest_events` overwrites `Event.venue_address` with the canonical address when `venue_name` matches, regardless of source-priority merge semantics. This was added because Visit Madison sometimes ships malformed addresses (e.g. `701A E Washington Ave` for High Noon) that snap to wrong coordinates and clutter the displayed address card.
 
 To add a venue: lowercase the name as it appears in `Event.venue_name`, curl Nominatim with the canonical address to get verified coordinates, then add an entry. Add alt spellings (e.g. "orpheum theater" vs "orpheum theatre") as separate keys — matching is exact after lowercase + trim.
 

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -12,7 +12,14 @@ from app.scrapers.base import RawEvent
 
 logger = logging.getLogger(__name__)
 
-_FILLABLE_FIELDS = ("description", "end_at", "venue_name", "venue_address", "image_url")
+# Trust ranking for event sources — lower index = higher trust.
+# Mirrors SOURCE_PRIORITY in frontend/src/lib/sources.js; keep in sync when adding scrapers.
+SOURCE_PRIORITY = ["High Noon Saloon", "Ticketmaster", "Our Lives", "Isthmus", "Visit Madison"]
+
+# Fields that higher-priority sources may overwrite, not just fill when null.
+# title is included because a trusted venue source often has the canonical event name.
+_OVERWRITABLE_FIELDS = ("title", "description", "end_at", "venue_name", "venue_address", "image_url")
+
 FUZZY_TITLE_THRESHOLD = 0.65  # tuned empirically against the Isthmus + Visit Madison overlap
 
 
@@ -61,9 +68,15 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
             inserted += 1
         else:
             changed = False
-            for field in _FILLABLE_FIELDS:
-                if getattr(event, field) is None and getattr(raw, field) is not None:
-                    setattr(event, field, getattr(raw, field))
+            incoming_rank = _source_rank(source_name)
+            existing_rank = _best_existing_rank(event, db)
+            is_higher_priority = incoming_rank < existing_rank
+            for field in _OVERWRITABLE_FIELDS:
+                raw_val = getattr(raw, field)
+                if raw_val is None:
+                    continue
+                if getattr(event, field) is None or is_higher_priority:
+                    setattr(event, field, raw_val)
                     changed = True
             if raw.categories:
                 existing = list(event.categories or [])
@@ -187,6 +200,20 @@ def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
         )
         return best
     return None
+
+
+def _source_rank(source_name: str) -> int:
+    try:
+        return SOURCE_PRIORITY.index(source_name)
+    except ValueError:
+        return len(SOURCE_PRIORITY)
+
+
+def _best_existing_rank(event: Event, db: Session) -> float:
+    rows = db.query(EventSource).filter_by(event_id=event.id, is_active=True).all()
+    if not rows:
+        return float("inf")
+    return min(_source_rank(r.source_name) for r in rows)
 
 
 def _apply_canonical_address(event: Event) -> None:

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -265,3 +265,53 @@ def test_non_canonical_venue_address_is_left_untouched(db):
 
     event = db.query(Event).one()
     assert event.venue_address == "999 Fake Street, Madison, WI"
+
+
+# ---------------------------------------------------------------------------
+# 9. Source-priority overwrite (#114): higher-trust source overwrites fields
+#    set by a lower-trust source; lower-trust source cannot overwrite back.
+# ---------------------------------------------------------------------------
+
+def test_higher_priority_source_overwrites_description(db):
+    # Visit Madison (rank 4, lowest trust) runs first with a thin description.
+    vm_event = _raw(
+        source_name="Visit Madison",
+        source_url="https://visitmadison.com/event/1",
+        description="Check out the event website for more information.",
+    )
+    ingest_events("Visit Madison", [vm_event], db)
+
+    event = db.query(Event).one()
+    assert event.description == "Check out the event website for more information."
+
+    # High Noon (rank 0, highest trust) runs second with a richer description.
+    hn_event = _raw(
+        source_name="High Noon Saloon",
+        source_url="https://highnoonsaloon.com/event/1",
+        description="Jackie Venson performs her soulful blend of blues and rock.",
+    )
+    ingest_events("High Noon Saloon", [hn_event], db)
+
+    db.refresh(event)
+    assert event.description == "Jackie Venson performs her soulful blend of blues and rock."
+
+
+def test_lower_priority_source_does_not_overwrite(db):
+    # High Noon (rank 0) runs first with a good description.
+    hn_event = _raw(
+        source_name="High Noon Saloon",
+        source_url="https://highnoonsaloon.com/event/1",
+        description="Jackie Venson performs her soulful blend of blues and rock.",
+    )
+    ingest_events("High Noon Saloon", [hn_event], db)
+
+    # Visit Madison (rank 4) runs second with a worse description — must not win.
+    vm_event = _raw(
+        source_name="Visit Madison",
+        source_url="https://visitmadison.com/event/1",
+        description="Check out the event website for more information.",
+    )
+    ingest_events("Visit Madison", [vm_event], db)
+
+    event = db.query(Event).one()
+    assert event.description == "Jackie Venson performs her soulful blend of blues and rock."


### PR DESCRIPTION
## Summary

- Replaces fill-in-nulls merge logic with source-priority merge semantics in `backend/app/ingest.py`
- When an incoming source has higher trust rank than all sources already linked to an event, it overwrites `_OVERWRITABLE_FIELDS` (title, description, end_at, venue_name, venue_address, image_url) for any non-null field it provides
- Lower- or equal-priority sources retain the existing fill-in-null-only behavior
- `SOURCE_PRIORITY` in `ingest.py` mirrors the existing `SOURCE_PRIORITY` in `frontend/src/lib/sources.js` — keep the two in sync when adding scrapers

Before this fix: Visit Madison's thin description ("Check out the event website for more information.") was locked in for Jackie Venson and other High Noon shows, because Visit Madison runs before High Noon in `SCRAPERS` and fill-in-nulls never overwrites an already-set field. After: High Noon's presenter + support-act descriptions win for all shared events.

closes #114

## Verification

- [x] Lint passes (`ruff check backend/`)
- [x] All 160 tests pass, including 2 new regression tests: `test_higher_priority_source_overwrites_description` and `test_lower_priority_source_does_not_overwrite`
- [x] Scrape triggered against live Docker stack — Jackie Venson and all 8 High Noon + Visit Madison dual-source events now show High Noon's richer descriptions
- [ ] In the browser, open a Jackie Venson or other High Noon show card and confirm the description is the detailed one (presenter/support-act format), not "Check out the event website for more information."