### PR TITLE
Add free-text event search (closes #111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,10 @@ start_at::date <= requested_date AND coalesce(end_at, start_at)::date >= request
 
 Only `status = 'active'` events are returned.
 
+### Search
+
+`GET /events/search?q=<query>` (`backend/app/routers/events.py`) returns active, today-or-future events whose title, description, or venue_name match the query (case-insensitive substring), ordered by `start_at` ascending and capped at `SEARCH_RESULT_LIMIT` (200). Empty/whitespace query returns `[]`. The endpoint deliberately ignores the frontend's category and venue filters — the typed query is the only filter, so users searching by name aren't surprised by an empty result set caused by a stale filter.
+
 ### Database
 
 - Tables are created at startup via `Base.metadata.create_all()` — no migration runner yet.
@@ -173,6 +177,10 @@ The expanded-detail modal is shared: `frontend/src/components/EventModal.jsx` is
 ### List vs Map view
 
 The header has a List/Map segmented toggle. Both views consume the same `filteredEvents` array from `App.jsx`, so date / category / venue filters apply identically to both. View mode is persisted to localStorage under `whats-up-madison.viewMode`. List view renders the time-bucketed sections + density rail; map view renders `MapView.jsx` (Leaflet + react-leaflet, with `react-leaflet-cluster` for low-zoom clustering). Pins group co-located events (lat/lng to 5 decimal places ≈ 1m) into a single marker with a count badge; multi-event popups list `time — title` rows that each open `EventModal`. Events without coordinates are surfaced in a collapsible "events without a location" panel below the map so they're never dropped from view. When adding a new filter or selection that should affect the visible event set, apply it to `filteredEvents` in `App.jsx` and both views pick it up automatically.
+
+### Search
+
+`SearchBar` (`frontend/src/components/SearchBar.jsx`) lives in the header. Typing a non-empty query (debounced 250ms) hits `GET /events/search?q=` and replaces the date-based view with `SearchResults` (`frontend/src/components/SearchResults.jsx`), which groups matching events under sticky local-date headers and renders each event with the standard `EventCard`. While searching, the List/Map toggle, category/venue filters, and date picker are hidden — they don't apply to search results. Clearing the input (× button or Escape while focused) restores the date view.
 
 ```
 cd frontend

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,7 +1,7 @@
 import datetime
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
@@ -9,6 +9,8 @@ from app.models import Event
 from app.schemas import EventResponse
 
 router = APIRouter(prefix="/events", tags=["events"])
+
+SEARCH_RESULT_LIMIT = 200
 
 
 @router.get("", response_model=list[EventResponse])
@@ -25,5 +27,37 @@ def get_events(
             func.date(func.timezone("America/Chicago", func.coalesce(Event.end_at, Event.start_at))) >= date,
         )
         .order_by(Event.start_at)
+        .all()
+    )
+
+
+@router.get("/search", response_model=list[EventResponse])
+def search_events(
+    q: str = "",
+    db: Session = Depends(get_db),
+):
+    query = q.strip()
+    if not query:
+        return []
+
+    pattern = f"%{query}%"
+
+    return (
+        db.query(Event)
+        .options(joinedload(Event.sources))
+        .filter(
+            Event.status == "active",
+            func.date(
+                func.timezone("America/Chicago", func.coalesce(Event.end_at, Event.start_at))
+            )
+            >= func.date(func.timezone("America/Chicago", func.now())),
+            or_(
+                Event.title.ilike(pattern),
+                Event.description.ilike(pattern),
+                Event.venue_name.ilike(pattern),
+            ),
+        )
+        .order_by(Event.start_at)
+        .limit(SEARCH_RESULT_LIMIT)
         .all()
     )

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,264 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.ingest import ingest_events
+from app.main import app
+from app.models import Event
+from app.scrapers.base import RawEvent
+
+
+@pytest.fixture
+def client(db):
+    def _override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _future_dt(days_ahead: int = 7, hour: int = 19) -> datetime:
+    return (datetime.now(timezone.utc) + timedelta(days=days_ahead)).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    )
+
+
+def _past_dt(days_ago: int = 7, hour: int = 19) -> datetime:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).replace(
+        hour=hour, minute=0, second=0, microsecond=0
+    )
+
+
+def _raw(
+    title: str = "Concert in the Park",
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    source_name: str = "Source A",
+    source_url: str = "https://example.com/event/1",
+    description: str | None = None,
+    venue_name: str = "Garner Park",
+) -> RawEvent:
+    return RawEvent(
+        title=title,
+        start_at=start_at or _future_dt(),
+        end_at=end_at,
+        source_name=source_name,
+        source_url=source_url,
+        description=description,
+        venue_name=venue_name,
+        categories=[],
+        all_day=False,
+    )
+
+
+def test_empty_query_returns_empty(client, db):
+    ingest_events("Source A", [_raw()], db)
+    db.commit()
+
+    resp = client.get("/events/search?q=")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_whitespace_only_query_returns_empty(client, db):
+    ingest_events("Source A", [_raw()], db)
+    db.commit()
+
+    resp = client.get("/events/search?q=   ")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_title_match(client, db):
+    ingest_events(
+        "Source A",
+        [
+            _raw(title="Jazz Night at the Park", source_url="https://example.com/event/1"),
+            _raw(title="Yoga Class", venue_name="Studio B", source_url="https://example.com/event/2"),
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=jazz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Jazz Night at the Park"
+
+
+def test_description_match(client, db):
+    ingest_events(
+        "Source A",
+        [
+            _raw(
+                title="Quiet Evening",
+                description="A relaxing flute performance under the stars.",
+                source_url="https://example.com/event/3",
+            ),
+            _raw(title="Other", venue_name="Other Place", source_url="https://example.com/event/4"),
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=flute")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Quiet Evening"
+
+
+def test_venue_match(client, db):
+    ingest_events(
+        "Source A",
+        [
+            _raw(title="Show 1", venue_name="High Noon Saloon", source_url="https://example.com/event/5"),
+            _raw(title="Show 2", venue_name="Other Venue", source_url="https://example.com/event/6"),
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=high noon")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Show 1"
+
+
+def test_case_insensitive(client, db):
+    ingest_events("Source A", [_raw(title="Jazz Night")], db)
+    db.commit()
+
+    for query in ("jazz", "JAZZ", "JaZz"):
+        resp = client.get(f"/events/search?q={query}")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+
+def test_past_events_excluded(client, db):
+    ingest_events(
+        "Source A",
+        [
+            _raw(
+                title="Old Concert",
+                start_at=_past_dt(days_ago=14),
+                end_at=_past_dt(days_ago=14, hour=22),
+                source_url="https://example.com/event/old",
+            ),
+            _raw(
+                title="Future Concert",
+                start_at=_future_dt(days_ahead=14),
+                source_url="https://example.com/event/new",
+            ),
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=concert")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["title"] == "Future Concert"
+
+
+def test_multi_day_event_in_progress_is_included(client, db):
+    # Event started a week ago, ends a week from now — should appear today.
+    ingest_events(
+        "Source A",
+        [
+            _raw(
+                title="Multi-Day Festival",
+                start_at=_past_dt(days_ago=7),
+                end_at=_future_dt(days_ahead=7),
+            )
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=festival")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_removed_events_excluded(client, db):
+    ingest_events("Source A", [_raw(title="Active Concert")], db)
+    # Now remove it — second run with empty list deactivates the source and
+    # the event becomes status='removed'.
+    ingest_events("Source A", [], db)
+    db.commit()
+
+    event = db.query(Event).one()
+    assert event.status == "removed"
+
+    resp = client.get("/events/search?q=concert")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_results_ordered_by_start_at(client, db):
+    ingest_events(
+        "Source A",
+        [
+            _raw(
+                title="Concert C",
+                start_at=_future_dt(days_ahead=14),
+                source_url="https://example.com/event/c",
+            ),
+            _raw(
+                title="Concert A",
+                start_at=_future_dt(days_ahead=2),
+                source_url="https://example.com/event/a",
+            ),
+            _raw(
+                title="Concert B",
+                start_at=_future_dt(days_ahead=7),
+                source_url="https://example.com/event/b",
+            ),
+        ],
+        db,
+    )
+    db.commit()
+
+    resp = client.get("/events/search?q=concert")
+    assert resp.status_code == 200
+    titles = [e["title"] for e in resp.json()]
+    assert titles == ["Concert A", "Concert B", "Concert C"]
+
+
+def test_result_limit(client, db):
+    raws = [
+        _raw(
+            title=f"Concert {i:03d}",
+            start_at=_future_dt(days_ahead=1) + timedelta(minutes=i),
+            source_url=f"https://example.com/event/{i}",
+        )
+        for i in range(250)
+    ]
+    ingest_events("Source A", raws, db)
+    db.commit()
+
+    resp = client.get("/events/search?q=concert")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 200
+
+
+def test_response_includes_sources(client, db):
+    ingest_events("Source A", [_raw(title="Jazz Night")], db)
+    db.commit()
+
+    resp = client.get("/events/search?q=jazz")
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["sources"] == [
+        {"source_name": "Source A", "source_url": "https://example.com/event/1"}
+    ]

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,8 @@ import CategoryFilter from './components/CategoryFilter'
 import VenueFilter from './components/VenueFilter'
 import MapView from './components/MapView'
 import FeedbackModal from './components/FeedbackModal'
+import SearchBar from './components/SearchBar'
+import SearchResults from './components/SearchResults'
 import { partitionEvents } from './lib/eventTime'
 import {
   filterEvents,
@@ -55,6 +57,13 @@ export default function App() {
   const [hiddenVenues, setHiddenVenues] = useState(loadHiddenVenues)
   const [viewMode, setViewMode] = useState(loadViewMode)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [searchResults, setSearchResults] = useState([])
+  const [searchLoading, setSearchLoading] = useState(false)
+  const [searchError, setSearchError] = useState(null)
+
+  const trimmedQuery = searchQuery.trim()
+  const isSearching = trimmedQuery.length > 0
 
   const headerRef = useRef(null)
   const [railEl, setRailEl] = useState(null)
@@ -92,6 +101,38 @@ export default function App() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
   }, [selectedDate])
+
+  useEffect(() => {
+    if (!isSearching) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSearchResults([])
+      setSearchError(null)
+      setSearchLoading(false)
+      return
+    }
+    setSearchLoading(true)
+    setSearchError(null)
+    const controller = new AbortController()
+    const timer = setTimeout(() => {
+      fetch(`${API_BASE}/events/search?q=${encodeURIComponent(trimmedQuery)}`, {
+        signal: controller.signal,
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`)
+          return res.json()
+        })
+        .then((data) => setSearchResults(data))
+        .catch((err) => {
+          if (err.name === 'AbortError') return
+          setSearchError(err.message)
+        })
+        .finally(() => setSearchLoading(false))
+    }, 250)
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [isSearching, trimmedQuery])
 
   useEffect(() => {
     saveFilterState(filter)
@@ -140,34 +181,41 @@ export default function App() {
             What's Up Madison
           </button>
           <div className="flex flex-wrap justify-center sm:flex-nowrap sm:justify-start items-center gap-2">
-            <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
-              <button
-                type="button"
-                onClick={() => setViewMode('list')}
-                className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-              >
-                List
-              </button>
-              <button
-                type="button"
-                onClick={() => setViewMode('map')}
-                className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
-              >
-                Map
-              </button>
-            </div>
+            <SearchBar value={searchQuery} onChange={setSearchQuery} />
+            {!isSearching && (
+              <div className="inline-flex border border-gray-300 rounded overflow-hidden text-sm">
+                <button
+                  type="button"
+                  onClick={() => setViewMode('list')}
+                  className={`px-3 py-1 cursor-pointer ${viewMode === 'list' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+                >
+                  List
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode('map')}
+                  className={`px-3 py-1 cursor-pointer ${viewMode === 'map' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}
+                >
+                  Map
+                </button>
+              </div>
+            )}
             <div className="flex items-center gap-2">
-              <CategoryFilter
-                selected={filter.selected}
-                includeUncategorized={filter.includeUncategorized}
-                onChange={setFilter}
-              />
-              <VenueFilter
-                allVenues={allVenues}
-                hiddenVenues={hiddenVenues}
-                onChange={setHiddenVenues}
-              />
-              <DatePicker value={selectedDate} onChange={setSelectedDate} />
+              {!isSearching && (
+                <>
+                  <CategoryFilter
+                    selected={filter.selected}
+                    includeUncategorized={filter.includeUncategorized}
+                    onChange={setFilter}
+                  />
+                  <VenueFilter
+                    allVenues={allVenues}
+                    hiddenVenues={hiddenVenues}
+                    onChange={setHiddenVenues}
+                  />
+                  <DatePicker value={selectedDate} onChange={setSelectedDate} />
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -175,45 +223,57 @@ export default function App() {
 
       <div className="max-w-7xl mx-auto px-4 pt-4 pb-6">
         <div>
-          {loading && <p className="text-gray-400 text-sm">Loading…</p>}
-          {error && <p className="text-red-500 text-sm">Error: {error}</p>}
-          {!loading && !error && events.length === 0 && (
-            <p className="text-gray-400 text-sm">No events found for this date.</p>
-          )}
-          {!loading && !error && events.length > 0 && filteredEvents.length === 0 && (
-            <p className="text-gray-400 text-sm">
-              All {events.length} events for this date are hidden by your filter.
-            </p>
-          )}
-          {!loading && !error && filteredEvents.length > 0 && (
+          {isSearching ? (
+            <SearchResults
+              query={trimmedQuery}
+              events={searchResults}
+              loading={searchLoading}
+              error={searchError}
+              stickyTop={headerH}
+            />
+          ) : (
             <>
-              <p className="text-gray-500 text-xs mb-2">
-                {filteredEvents.length} event{filteredEvents.length !== 1 ? 's' : ''}
-                {filteredEvents.length !== events.length && (
-                  <span className="text-gray-400"> of {events.length}</span>
-                )}
-              </p>
-              {viewMode === 'list' ? (
+              {loading && <p className="text-gray-400 text-sm">Loading…</p>}
+              {error && <p className="text-red-500 text-sm">Error: {error}</p>}
+              {!loading && !error && events.length === 0 && (
+                <p className="text-gray-400 text-sm">No events found for this date.</p>
+              )}
+              {!loading && !error && events.length > 0 && filteredEvents.length === 0 && (
+                <p className="text-gray-400 text-sm">
+                  All {events.length} events for this date are hidden by your filter.
+                </p>
+              )}
+              {!loading && !error && filteredEvents.length > 0 && (
                 <>
-                  <DensityRail
-                    ref={setRailEl}
-                    stickyTop={headerH}
-                    hourCounts={partition.hourCounts}
-                    onJumpToHour={handleJumpToHour}
-                  />
-                  <AllDayStrip events={partition.allday} stickyTop={headerH + railH} />
-                  {BUCKETS.map((b) => (
-                    <BucketSection
-                      key={b.id}
-                      id={b.id}
-                      label={b.label}
-                      events={partition[b.id]}
-                      stickyTop={headerH + railH}
-                    />
-                  ))}
+                  <p className="text-gray-500 text-xs mb-2">
+                    {filteredEvents.length} event{filteredEvents.length !== 1 ? 's' : ''}
+                    {filteredEvents.length !== events.length && (
+                      <span className="text-gray-400"> of {events.length}</span>
+                    )}
+                  </p>
+                  {viewMode === 'list' ? (
+                    <>
+                      <DensityRail
+                        ref={setRailEl}
+                        stickyTop={headerH}
+                        hourCounts={partition.hourCounts}
+                        onJumpToHour={handleJumpToHour}
+                      />
+                      <AllDayStrip events={partition.allday} stickyTop={headerH + railH} />
+                      {BUCKETS.map((b) => (
+                        <BucketSection
+                          key={b.id}
+                          id={b.id}
+                          label={b.label}
+                          events={partition[b.id]}
+                          stickyTop={headerH + railH}
+                        />
+                      ))}
+                    </>
+                  ) : (
+                    <MapView events={filteredEvents} stickyTop={headerH} />
+                  )}
                 </>
-              ) : (
-                <MapView events={filteredEvents} stickyTop={headerH} />
               )}
             </>
           )}

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react'
+import { Search, X } from 'lucide-react'
+
+export default function SearchBar({ value, onChange }) {
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (!value) return
+    function handleKey(e) {
+      if (e.key === 'Escape' && document.activeElement === inputRef.current) {
+        onChange('')
+        inputRef.current?.blur()
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [value, onChange])
+
+  return (
+    <div className="relative flex items-center">
+      <Search
+        size={14}
+        className="absolute left-2 text-gray-400 pointer-events-none"
+        aria-hidden="true"
+      />
+      <input
+        ref={inputRef}
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search events…"
+        aria-label="Search events"
+        className="border border-gray-300 rounded-md pl-7 pr-7 py-1 text-sm text-gray-900 placeholder-gray-400 w-44 sm:w-56 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => { onChange(''); inputRef.current?.focus() }}
+          aria-label="Clear search"
+          className="absolute right-1.5 p-0.5 text-gray-400 hover:text-gray-700 cursor-pointer"
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react'
+import EventCard from './EventCard'
+import { formatLocalDate, localYMD } from '../lib/eventTime'
+
+function todayLocalYMD() {
+  return new Date().toLocaleDateString('en-CA')
+}
+
+function groupByDate(events) {
+  const today = todayLocalYMD()
+  const groups = new Map()
+  for (const event of events) {
+    // Multi-day event in progress: bucket under today rather than its start date.
+    let key = localYMD(event.start_at)
+    if (key < today) key = today
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push(event)
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([ymd, evs]) => ({ ymd, events: evs }))
+}
+
+export default function SearchResults({ query, events, loading, error, stickyTop }) {
+  const groups = useMemo(() => groupByDate(events), [events])
+
+  if (loading) return <p className="text-gray-400 text-sm">Searching…</p>
+  if (error) return <p className="text-red-500 text-sm">Error: {error}</p>
+  if (events.length === 0) {
+    return (
+      <p className="text-gray-400 text-sm">
+        No upcoming events match “{query}”.
+      </p>
+    )
+  }
+
+  return (
+    <>
+      <p className="text-gray-500 text-xs mb-2">
+        {events.length} matching event{events.length === 1 ? '' : 's'}
+      </p>
+      {groups.map(({ ymd, events: evs }) => (
+        <section key={ymd} className="mt-6 first:mt-2">
+          <h2
+            style={{ top: stickyTop }}
+            className="sticky z-10 bg-blue-50 border border-blue-200 text-blue-900 rounded-md px-3 py-1.5 text-sm font-semibold flex items-center justify-between"
+          >
+            <span>{formatLocalDate(`${ymd}T12:00:00Z`)}</span>
+            <span className="text-xs font-normal opacity-70">
+              {evs.length} event{evs.length === 1 ? '' : 's'}
+            </span>
+          </h2>
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 items-start">
+            {evs.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </>
+  )
+}

--- a/frontend/src/lib/eventTime.js
+++ b/frontend/src/lib/eventTime.js
@@ -24,6 +24,13 @@ const minuteFmt = new Intl.DateTimeFormat('en-US', {
   timeZone: TZ,
 })
 
+const dateHeaderFmt = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+  timeZone: TZ,
+})
+
 export function formatTime(iso) {
   return timeFmt.format(new Date(iso))
 }
@@ -33,12 +40,16 @@ export function formatTimeRange(start, end) {
   return `${formatTime(start)} – ${formatTime(end)}`
 }
 
+export function formatLocalDate(iso) {
+  return dateHeaderFmt.format(new Date(iso))
+}
+
 export function localHour(iso) {
   const h = parseInt(hourFmt.format(new Date(iso)), 10)
   return h === 24 ? 0 : h
 }
 
-function localYMD(iso) {
+export function localYMD(iso) {
   return ymdFmt.format(new Date(iso))
 }
 


### PR DESCRIPTION
Closes #111.

## Summary
- New `GET /events/search?q=` backend endpoint: case-insensitive ILIKE on title/description/venue, today-or-future only, ordered by start_at, capped at 200.
- New `SearchBar` in the header with debounced (250ms) querying, clear button, and Escape-to-clear.
- New `SearchResults` view that groups matching events under sticky local-date headers (per the issue, the date is prominently displayed since results span many days). Reuses the existing `EventCard`.
- While searching the date-based controls (List/Map toggle, category/venue filters, date picker) hide because they don't apply — the typed query is the only filter.
- 12 new tests in `backend/tests/test_search.py`; brief docs added in `AGENTS.md`.

## Verification
- [x] `~/miniconda3/envs/whats-up-madison/bin/ruff check backend/` passes
- [x] `cd frontend && npm run lint` passes
- [x] `pytest backend/tests/` — 172/172 pass (12 new tests)
- [x] `cd frontend && npm run build` succeeds
- [x] `curl 'http://localhost:8000/events/search?q='` → `[]`
- [x] `curl 'http://localhost:8000/events/search?q=high%20noon'` → 88 results, all at "High Noon Saloon"
- [x] Result list ordered by `start_at` ascending
- [x] `curl 'http://localhost:8000/events/search?q=e'` returns exactly 200 (limit honored)
- [x] Vite dev server proxies `/events/search` correctly
- [x] Type a query in the search box and confirm the date view is replaced with grouped results
- [x] Confirm sticky date headers behave correctly while scrolling
- [x] Confirm the × button and Escape key both clear the search
- [x] Confirm the header layout wraps cleanly on mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)