### PR TITLE
Add targeted-scrape options to /admin/scrape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@ class MySource(BaseSource):
 
 After writing a scraper, add it to `SCRAPERS` in `backend/app/main.py`. The `POST /admin/scrape` endpoint triggers all registered scrapers.
 
+When iterating on a scraper, use the `?scraper=…&days=…&skip_geocode=true&skip_tag=true` form of `/admin/scrape` (see *Triggering a Scrape (Dev)* below) — running the full no-arg pipeline for every code change is the slow path.
+
 `fetch()` accepts an optional `window_days` arg so `/admin/scrape?days=N` can narrow the forward window for testing. API/iCal-based scrapers should honor it (`end = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)`); HTML-calendar scrapers that have no controllable window (High Noon, Atwood, Overture) accept the arg, ignore it, and set the class attribute `supports_window_days = False` so the endpoint can flag the no-op in its response.
 
 `RawEvent.canonical_hash()` generates a deduplication key: `sha256(normalized_title|start_date|venue_name)`. Always set `source_name` and `source_url` on every `RawEvent`.
@@ -201,6 +203,8 @@ npm run build    # production build
 
 ## Triggering a Scrape (Dev)
 
+**Default to targeted runs when iterating on scraper code.** A full no-arg `/admin/scrape` runs all seven sources, geocodes everything new via Nominatim, then runs the LLM tagger over every untagged event — multiple minutes plus real Anthropic + OSM spend. Most scraper changes only need to verify one source's `fetch()` output, so pass `?scraper=<name>&days=<small N>&skip_geocode=true&skip_tag=true` and drop the flags only for end-to-end checks or the scheduled job.
+
 ```
 curl -X POST http://localhost:8000/admin/scrape
 ```
@@ -208,7 +212,7 @@ curl -X POST http://localhost:8000/admin/scrape
 Returns per-scraper stats including ingestion + geocoding:
 `{"Isthmus": {"inserted": N, "updated": N, "deactivated": N, "geocoded": N, "geocode_misses": N, "geocode_skipped": N}}`.
 
-For faster iteration when changing a single scraper, narrow what runs with query params (all optional, all combinable):
+The following query params are all optional and all combinable:
 
 - `scraper=<name>` (repeatable) — run only the named scrapers. Names must match `BaseSource.name` exactly. Unknown names return HTTP 400 with the valid set.
 - `days=<N>` — override the forward window passed to `fetch(window_days=N)`. Honored by the API/iCal scrapers (Isthmus, Visit Madison, Our Lives, Ticketmaster); the HTML scrapers (High Noon Saloon, Atwood Music Hall, Overture Center for the Arts) ignore it and the response includes `"window_days_honored": false` to make that explicit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,11 +53,13 @@ class MySource(BaseSource):
     name = "My Source"
     scraper_type = "ical"  # api | ical | html
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         ...
 ```
 
 After writing a scraper, add it to `SCRAPERS` in `backend/app/main.py`. The `POST /admin/scrape` endpoint triggers all registered scrapers.
+
+`fetch()` accepts an optional `window_days` arg so `/admin/scrape?days=N` can narrow the forward window for testing. API/iCal-based scrapers should honor it (`end = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)`); HTML-calendar scrapers that have no controllable window (High Noon, Atwood, Overture) accept the arg, ignore it, and set the class attribute `supports_window_days = False` so the endpoint can flag the no-op in its response.
 
 `RawEvent.canonical_hash()` generates a deduplication key: `sha256(normalized_title|start_date|venue_name)`. Always set `source_name` and `source_url` on every `RawEvent`.
 
@@ -205,6 +207,19 @@ curl -X POST http://localhost:8000/admin/scrape
 
 Returns per-scraper stats including ingestion + geocoding:
 `{"Isthmus": {"inserted": N, "updated": N, "deactivated": N, "geocoded": N, "geocode_misses": N, "geocode_skipped": N}}`.
+
+For faster iteration when changing a single scraper, narrow what runs with query params (all optional, all combinable):
+
+- `scraper=<name>` (repeatable) — run only the named scrapers. Names must match `BaseSource.name` exactly. Unknown names return HTTP 400 with the valid set.
+- `days=<N>` — override the forward window passed to `fetch(window_days=N)`. Honored by the API/iCal scrapers (Isthmus, Visit Madison, Our Lives, Ticketmaster); the HTML scrapers (High Noon Saloon, Atwood Music Hall, Overture Center for the Arts) ignore it and the response includes `"window_days_honored": false` to make that explicit.
+- `skip_geocode=true` — skip the per-source geocoding pass.
+- `skip_tag=true` — skip the global LLM tagging pass.
+
+Example — re-run just Isthmus over the next 3 days with no geocode/tag work:
+
+```
+curl -X POST 'http://localhost:8000/admin/scrape?scraper=Isthmus&days=3&skip_geocode=true&skip_tag=true'
+```
 
 To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost:8000/admin/geocode'` (add `?force=true` to clear non-success cache rows and retry previously-failed lookups).
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from typing import Optional
 
 import httpx
-from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
@@ -16,6 +16,7 @@ from app.ingest import ingest_events
 from app.routers import events
 from app.schemas import FeedbackRequest
 from app.scrapers.atwood import AtwoodMusicHallSource
+from app.scrapers.base import BaseSource
 from app.scrapers.high_noon import HighNoonSource
 from app.scrapers.isthmus import IsthmusSource
 from app.scrapers.our_lives import OurLivesSource
@@ -121,31 +122,73 @@ async def submit_feedback(request: FeedbackRequest):
     return {"ok": True, "issue_url": resp.json()["html_url"]}
 
 
+def _select_scrapers(names: list[str]) -> list[BaseSource]:
+    """Return the SCRAPERS subset matching `names` (exact match on .name).
+
+    Empty `names` means "all". Unknown names → HTTP 400 with the valid set.
+    """
+    if not names:
+        return list(SCRAPERS)
+    by_name = {s.name: s for s in SCRAPERS}
+    unknown = [n for n in names if n not in by_name]
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "unknown scraper name(s)",
+                "unknown": unknown,
+                "available": sorted(by_name),
+            },
+        )
+    # Preserve declaration order in SCRAPERS, not the order names were passed,
+    # so repeated runs are deterministic regardless of curl arg order.
+    requested = set(names)
+    return [s for s in SCRAPERS if s.name in requested]
+
+
 @app.post("/admin/scrape")
-def trigger_scrape(_: None = Depends(require_admin_key), db: Session = Depends(get_db)):
+def trigger_scrape(
+    scraper: list[str] = Query(default_factory=list),
+    days: Optional[int] = Query(default=None, ge=1),
+    skip_geocode: bool = False,
+    skip_tag: bool = False,
+    _: None = Depends(require_admin_key),
+    db: Session = Depends(get_db),
+):
+    selected = _select_scrapers(scraper)
     results = {}
-    for scraper in SCRAPERS:
-        logger.info("Starting scrape: %s", scraper.name)
+    for s in selected:
+        logger.info(
+            "Starting scrape: %s (window_days=%s, skip_geocode=%s, skip_tag=%s)",
+            s.name, days, skip_geocode, skip_tag,
+        )
         try:
-            raw = scraper.fetch()
-            stats = ingest_events(scraper.name, raw, db)
-            results[scraper.name] = stats
-            logger.info("Scrape complete: %s — %s", scraper.name, stats)
+            raw = s.fetch(window_days=days)
+            stats = ingest_events(s.name, raw, db)
+            results[s.name] = stats
+            logger.info("Scrape complete: %s — %s", s.name, stats)
         except Exception as e:
-            results[scraper.name] = {"error": str(e)}
-            logger.warning("Scrape failed: %s — %s", scraper.name, e)
+            results[s.name] = {"error": str(e)}
+            logger.warning("Scrape failed: %s — %s", s.name, e)
+            continue
+        if days is not None and not s.supports_window_days:
+            # Surface the no-op so a caller passing ?days=N knows the filter
+            # didn't apply to this HTML-calendar scraper.
+            results[s.name]["window_days_honored"] = False
+        if skip_geocode:
             continue
         try:
-            geo_stats = geocode_missing_for_source(scraper.name, db)
-            results[scraper.name] = {**results[scraper.name], **geo_stats}
-            logger.info("Geocode complete: %s — %s", scraper.name, geo_stats)
+            geo_stats = geocode_missing_for_source(s.name, db)
+            results[s.name] = {**results[s.name], **geo_stats}
+            logger.info("Geocode complete: %s — %s", s.name, geo_stats)
         except Exception as e:
-            results[scraper.name]["geocode_error"] = str(e)
-            logger.warning("Geocode failed: %s — %s", scraper.name, e)
-    try:
-        results["_tagging"] = tag_untagged_events(db)
-    except Exception as e:
-        results["_tagging"] = {"error": str(e)}
+            results[s.name]["geocode_error"] = str(e)
+            logger.warning("Geocode failed: %s — %s", s.name, e)
+    if not skip_tag:
+        try:
+            results["_tagging"] = tag_untagged_events(db)
+        except Exception as e:
+            results["_tagging"] = {"error": str(e)}
     return results
 
 

--- a/backend/app/scrapers/atwood.py
+++ b/backend/app/scrapers/atwood.py
@@ -32,8 +32,9 @@ _DESC_DOORS_RE = re.compile(
 class AtwoodMusicHallSource(BaseSource):
     name = "Atwood Music Hall"
     scraper_type = "html"
+    supports_window_days = False
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         resp = http_get_with_retry(_CALENDAR_URL, timeout=30)
         soup = BeautifulSoup(resp.content, "lxml")
         events: list[RawEvent] = []

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -79,6 +79,10 @@ def clean_html_text(s: str) -> str:
 class BaseSource:
     name: str = ""
     scraper_type: str = ""
+    # False when the source has no controllable forward-window (HTML calendar
+    # pages that just render what's posted). The /admin/scrape endpoint uses
+    # this to flag in its response that the `days` filter was a no-op.
+    supports_window_days: bool = True
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         raise NotImplementedError

--- a/backend/app/scrapers/high_noon.py
+++ b/backend/app/scrapers/high_noon.py
@@ -39,8 +39,9 @@ _NON_MUSIC_MAP: dict[str, str] = {
 class HighNoonSource(BaseSource):
     name = "High Noon Saloon"
     scraper_type = "html"
+    supports_window_days = False
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         resp = http_get_with_retry(_CALENDAR_URL, timeout=30)
         soup = BeautifulSoup(resp.content, "lxml")
         events: list[RawEvent] = []

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -39,12 +39,12 @@ class IsthmusSource(BaseSource):
     name = "Isthmus"
     scraper_type = "ical"
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         # Use Central time, not the container's clock — backend runs in UTC, so
         # date.today() returns tomorrow's date after ~7 PM Central, cutting off
         # today's events from the scrape window.
         today = datetime.now(_CENTRAL).date()
-        end_date = today + timedelta(days=_WINDOW_DAYS)
+        end_date = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
         url_map, title_date_map = _build_url_map(today, end_date)
         return _parse_ical(today, end_date, url_map, title_date_map)
 

--- a/backend/app/scrapers/our_lives.py
+++ b/backend/app/scrapers/our_lives.py
@@ -53,9 +53,9 @@ class OurLivesSource(BaseSource):
     name = "Our Lives"
     scraper_type = "api"
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         today = datetime.now(_CENTRAL).date()
-        end = today + timedelta(days=_WINDOW_DAYS)
+        end = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
         events: list[RawEvent] = []
         page = 1
         while True:

--- a/backend/app/scrapers/overture.py
+++ b/backend/app/scrapers/overture.py
@@ -132,8 +132,9 @@ class _ParsedDate:
 class OvertureSource(BaseSource):
     name = _SOURCE_NAME
     scraper_type = "html"
+    supports_window_days = False
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         session, listing_html = _fetch_listing()
         if not listing_html:
             return []

--- a/backend/app/scrapers/ticketmaster.py
+++ b/backend/app/scrapers/ticketmaster.py
@@ -35,12 +35,12 @@ class TicketmasterSource(BaseSource):
     name = "Ticketmaster"
     scraper_type = "api"
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         if not settings.ticketmaster_api_key:
             raise ValueError("TICKETMASTER_API_KEY is not set")
 
         today = datetime.now(_CENTRAL).date()
-        end = today + timedelta(days=_WINDOW_DAYS)
+        end = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
         start_iso = _utc_iso_z(datetime.combine(today, dtime.min, tzinfo=_CENTRAL))
         end_iso = _utc_iso_z(datetime.combine(end, dtime.max, tzinfo=_CENTRAL))
 

--- a/backend/app/scrapers/visit_madison.py
+++ b/backend/app/scrapers/visit_madison.py
@@ -61,10 +61,10 @@ class VisitMadisonSource(BaseSource):
     name = "Visit Madison"
     scraper_type = "api"
 
-    def fetch(self) -> list[RawEvent]:
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         token = _fetch_token()
         today = datetime.now(_CENTRAL).date()
-        end = today + timedelta(days=_WINDOW_DAYS)
+        end = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
         start_iso = _client_midnight_z(today)
         end_iso = _client_midnight_z(end)
 

--- a/backend/tests/test_admin_scrape.py
+++ b/backend/tests/test_admin_scrape.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main as main_module
+from app.database import get_db
+from app.main import app
+from app.scrapers.base import BaseSource, RawEvent
+
+
+class _FakeSource(BaseSource):
+    """In-memory BaseSource that records fetch() calls and returns a fixed list."""
+
+    def __init__(self, name: str, supports_window: bool, raws: list[RawEvent]):
+        self.name = name
+        self.scraper_type = "test"
+        self.supports_window_days = supports_window
+        self._raws = raws
+        self.fetch_calls: list[int | None] = []
+
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
+        self.fetch_calls.append(window_days)
+        return list(self._raws)
+
+
+def _raw(title: str, source_name: str) -> RawEvent:
+    return RawEvent(
+        title=title,
+        start_at=datetime(2026, 6, 15, 19, 0, 0, tzinfo=timezone.utc),
+        source_name=source_name,
+        source_url=f"https://example.com/{title.lower().replace(' ', '-')}",
+        venue_name="Test Venue",
+    )
+
+
+@pytest.fixture
+def fakes(monkeypatch):
+    """Replace SCRAPERS, geocoding, and tagging with hermetic stubs."""
+    fake_a = _FakeSource("Fake A", supports_window=True, raws=[_raw("Show A", "Fake A")])
+    fake_b = _FakeSource("Fake B", supports_window=False, raws=[_raw("Show B", "Fake B")])
+    monkeypatch.setattr(main_module, "SCRAPERS", [fake_a, fake_b])
+
+    geocode_calls: list[str] = []
+
+    def fake_geocode(name, _db):
+        geocode_calls.append(name)
+        return {"geocoded": 0, "geocode_misses": 0, "geocode_skipped": 0}
+
+    monkeypatch.setattr(main_module, "geocode_missing_for_source", fake_geocode)
+
+    tag_calls: list[None] = []
+
+    def fake_tag(_db, model=None):
+        tag_calls.append(None)
+        return {"tagged": 0, "batches": 0}
+
+    monkeypatch.setattr(main_module, "tag_untagged_events", fake_tag)
+
+    return {
+        "a": fake_a,
+        "b": fake_b,
+        "geocode_calls": geocode_calls,
+        "tag_calls": tag_calls,
+    }
+
+
+@pytest.fixture
+def client(db):
+    def _override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_no_params_runs_all_scrapers(client, fakes):
+    resp = client.post("/admin/scrape")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "Fake A" in body
+    assert "Fake B" in body
+    assert "_tagging" in body
+    assert fakes["a"].fetch_calls == [None]
+    assert fakes["b"].fetch_calls == [None]
+    assert fakes["geocode_calls"] == ["Fake A", "Fake B"]
+    assert len(fakes["tag_calls"]) == 1
+
+
+def test_single_scraper_filter(client, fakes):
+    resp = client.post("/admin/scrape?scraper=Fake A")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "Fake A" in body
+    assert "Fake B" not in body
+    assert fakes["a"].fetch_calls == [None]
+    assert fakes["b"].fetch_calls == []
+    assert fakes["geocode_calls"] == ["Fake A"]
+
+
+def test_multiple_scraper_filter_preserves_declaration_order(client, fakes):
+    # Pass B before A; response order should still mirror SCRAPERS, not query order.
+    resp = client.post("/admin/scrape?scraper=Fake B&scraper=Fake A")
+    assert resp.status_code == 200
+    # Both run, both geocode in declaration order.
+    assert fakes["geocode_calls"] == ["Fake A", "Fake B"]
+    assert fakes["a"].fetch_calls == [None]
+    assert fakes["b"].fetch_calls == [None]
+
+
+def test_unknown_scraper_returns_400_with_available_set(client, fakes):
+    resp = client.post("/admin/scrape?scraper=Bogus")
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["unknown"] == ["Bogus"]
+    assert set(detail["available"]) == {"Fake A", "Fake B"}
+    # Nothing should have run.
+    assert fakes["a"].fetch_calls == []
+    assert fakes["b"].fetch_calls == []
+    assert fakes["geocode_calls"] == []
+    assert fakes["tag_calls"] == []
+
+
+def test_days_param_is_forwarded(client, fakes):
+    resp = client.post("/admin/scrape?days=7")
+    assert resp.status_code == 200
+    assert fakes["a"].fetch_calls == [7]
+    assert fakes["b"].fetch_calls == [7]
+    # Fake B does not support a window, so the response flags it.
+    body = resp.json()
+    assert body["Fake B"]["window_days_honored"] is False
+    # Fake A supports a window, so no flag is added.
+    assert "window_days_honored" not in body["Fake A"]
+
+
+def test_days_zero_rejected(client, fakes):
+    resp = client.post("/admin/scrape?days=0")
+    assert resp.status_code == 422
+    assert fakes["a"].fetch_calls == []
+
+
+def test_skip_geocode(client, fakes):
+    resp = client.post("/admin/scrape?skip_geocode=true")
+    assert resp.status_code == 200
+    assert fakes["geocode_calls"] == []
+    assert len(fakes["tag_calls"]) == 1
+
+
+def test_skip_tag(client, fakes):
+    resp = client.post("/admin/scrape?skip_tag=true")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "_tagging" not in body
+    assert fakes["tag_calls"] == []
+    assert fakes["geocode_calls"] == ["Fake A", "Fake B"]


### PR DESCRIPTION
closes #130

## Summary

Adds four optional query params to `POST /admin/scrape` so scraper iteration doesn't require a wholesale run of every source + geocode + LLM tag:

- `scraper=<name>` (repeatable) — run only the named scrapers. Unknown name → HTTP 400 with the valid set.
- `days=<N>` (≥1) — narrow the forward window. Threaded through every scraper's new `fetch(window_days=…)` signature. Honored by API/iCal scrapers (Isthmus, Visit Madison, Our Lives, Ticketmaster); HTML-calendar scrapers (High Noon Saloon, Atwood Music Hall, Overture Center for the Arts) accept-and-ignore. When ignored, the response includes `"window_days_honored": false`.
- `skip_geocode=true` — skip the per-source Nominatim pass.
- `skip_tag=true` — skip the global LLM tagging pass.

No-arg behavior is preserved exactly, so the Daily Scrape Action keeps working.

## Verification

- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/ -v` — 264 tests pass (8 new in `test_admin_scrape.py`)
- [x] `POST /admin/scrape?scraper=Isthmus&days=2&skip_geocode=true&skip_tag=true` — response has only `Isthmus` key, no `_tagging`, no geocode metrics
- [x] `POST /admin/scrape?scraper=Bogus` — HTTP 400 with available names in body
- [x] `POST /admin/scrape?days=0` — HTTP 422 (FastAPI `ge=1` validation)
- [x] `POST /admin/scrape?scraper=High+Noon+Saloon&days=2&skip_geocode=true&skip_tag=true` — succeeds; response flags `window_days_honored: false`
- [x] `docker compose logs backend` — no tracebacks; log lines show the per-call `window_days` / `skip_geocode` / `skip_tag` values
- [ ] CI lint + test jobs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)