### PR TITLE
Fix cross-source event dedup: venue normalization, Isthmus RSS fallback, TM canonical URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,12 +137,15 @@ Scrapers don't need to do anything special — populating `RawEvent.venue_addres
 
 #### Canonical venue registry (`backend/app/canonical_venues.py`)
 
-A small allowlist of well-known Madison venues (High Noon Saloon, The Sylvee, Majestic, Orpheum, Barrymore, Overture Center) maps `venue_name` → known-good `(latitude, longitude, address)`. Two consumers use it:
+A small allowlist of well-known Madison venues (High Noon Saloon, The Sylvee, Majestic, Orpheum, Barrymore, Overture Center) maps `venue_name` → known-good `(latitude, longitude, address, canonical_name)`. Three consumers use it:
 
 - `geocode_event` consults the registry **before** the cache or Nominatim — short-circuits the network call entirely, immune to upstream address quirks, and corrects already-bad coordinates on the next geocode pass.
 - `ingest_events` overwrites `Event.venue_address` with the canonical address when `venue_name` matches, regardless of source-priority merge semantics. This was added because Visit Madison sometimes ships malformed addresses (e.g. `701A E Washington Ave` for High Noon) that snap to wrong coordinates and clutter the displayed address card.
+- `ingest_events` also normalizes `venue_name` to the entry's `canonical_name` (when set) **before hashing**, so events from sources that use sub-room or alias names merge with events from sources that use the building name. For example, Isthmus's "Overture Center-Overture Hall" and Ticketmaster's "Overture Center for the Arts" both normalize to "Overture Center for the Arts" before dedup runs.
 
-To add a venue: lowercase the name as it appears in `Event.venue_name`, curl Nominatim with the canonical address to get verified coordinates, then add an entry. Add alt spellings (e.g. "orpheum theater" vs "orpheum theatre") as separate keys — matching is exact after lowercase + trim.
+`CanonicalVenue.canonical_name` is `None` for entries that are already the canonical form; set it only on alias/sub-room entries. All Overture sub-room entries (bare names like "Overture Hall", "Capitol Theater", and Isthmus-style compound names like "Overture Center-Overture Hall") carry `canonical_name = "Overture Center for the Arts"` and all point to a shared `_OVERTURE` sentinel so coordinates aren't duplicated.
+
+To add a venue: lowercase the name as it appears in `Event.venue_name`, curl Nominatim with the canonical address to get verified coordinates, then add an entry. Add alt spellings as separate keys pointing to the same `CanonicalVenue`. For sub-rooms or aliases that should collapse to a building name for dedup purposes, set `canonical_name` on those entries.
 
 ### Tagging (`backend/app/tagger.py`)
 

--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -19,7 +19,16 @@ class CanonicalVenue(NamedTuple):
     latitude: float
     longitude: float
     address: str
+    # When set, ingest normalizes venue_name to this string before hashing and
+    # dedup so events from sources that use sub-room names merge with events
+    # from sources that use the building name.
+    canonical_name: Optional[str] = None
 
+
+_OVERTURE = CanonicalVenue(
+    43.0741343, -89.3882773, "201 State St, Madison, WI 53703",
+    canonical_name="Overture Center for the Arts",
+)
 
 CANONICAL_VENUES: dict[str, CanonicalVenue] = {
     "high noon saloon": CanonicalVenue(
@@ -43,40 +52,31 @@ CANONICAL_VENUES: dict[str, CanonicalVenue] = {
     "barrymore theatre": CanonicalVenue(
         43.0930640, -89.3522665, "2090 Atwood Ave, Madison, WI 53704"
     ),
-    "overture center": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
+    # Overture Center building names — the canonical display name is
+    # "Overture Center for the Arts"; all sub-room and alias entries
+    # below carry canonical_name so ingest normalizes them before hashing.
     "overture center for the arts": CanonicalVenue(
         43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
     ),
-    # Sub-rooms physically inside Overture Center. The Overture scraper
-    # leaves the room name on venue_name (so it dedups cleanly with
-    # Ticketmaster's per-room values) and relies on this registry to
-    # keep geocoding and the displayed address pointing at the building.
-    "overture hall": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "capitol theater": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "capitol theater stage": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "promenade hall": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "promenade lobby": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "rotunda stage": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "the playhouse": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
-    "james watrous gallery": CanonicalVenue(
-        43.0741343, -89.3882773, "201 State St, Madison, WI 53703"
-    ),
+    "overture center": _OVERTURE,
+    # Sub-rooms by bare room name (Overture scraper, some sources)
+    "overture hall":          _OVERTURE,
+    "capitol theater":        _OVERTURE,
+    "capitol theater stage":  _OVERTURE,
+    "promenade hall":         _OVERTURE,
+    "promenade lobby":        _OVERTURE,
+    "rotunda stage":          _OVERTURE,
+    "the playhouse":          _OVERTURE,
+    "james watrous gallery":  _OVERTURE,
+    # "Venue-Subroom" compound format used by the Isthmus iCal/RSS feed
+    "overture center-overture hall":         _OVERTURE,
+    "overture center-capitol theater":       _OVERTURE,
+    "overture center-capitol theater stage": _OVERTURE,
+    "overture center-promenade hall":        _OVERTURE,
+    "overture center-promenade lobby":       _OVERTURE,
+    "overture center-rotunda stage":         _OVERTURE,
+    "overture center-the playhouse":         _OVERTURE,
+    "overture center-james watrous gallery": _OVERTURE,
 }
 
 
@@ -95,6 +95,21 @@ def lookup(venue_name: Optional[str]) -> Optional[CanonicalVenue]:
     if key is None:
         return None
     return CANONICAL_VENUES.get(key)
+
+
+def normalize_name(venue_name: Optional[str]) -> Optional[str]:
+    """Return the canonical display name for ``venue_name``.
+
+    If the registry entry has a ``canonical_name`` set (e.g. a sub-room or
+    alias entry), returns that name. Otherwise returns ``venue_name``
+    unchanged so callers can always use the return value directly.
+    """
+    if not venue_name:
+        return venue_name
+    entry = lookup(venue_name)
+    if entry is not None and entry.canonical_name is not None:
+        return entry.canonical_name
+    return venue_name
 
 
 def canonical_keys() -> list[str]:

--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import replace as dc_replace
 from datetime import datetime, timezone
 from difflib import SequenceMatcher
 
@@ -32,6 +33,12 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
     run_start = datetime.now(timezone.utc)
     inserted = 0
     updated = 0
+
+    # Normalize venue names to canonical building names before hashing so
+    # events from sources that use sub-room names (e.g. Isthmus iCal's
+    # "Overture Center-Overture Hall") merge with events from sources that
+    # use the building name (e.g. Ticketmaster's "Overture Center for the Arts").
+    raw_events = [_normalize_raw_venue(r) for r in raw_events]
 
     # Collapse raws that share a canonical_hash — a single source can return
     # multiple records that map to the same event (e.g. Visit Madison lists two
@@ -246,6 +253,13 @@ def _best_existing_rank(event: Event, db: Session) -> float:
     if not rows:
         return float("inf")
     return min(_source_rank(r.source_name) for r in rows)
+
+
+def _normalize_raw_venue(raw: RawEvent) -> RawEvent:
+    normalized = canonical_venues.normalize_name(raw.venue_name)
+    if normalized == raw.venue_name:
+        return raw
+    return dc_replace(raw, venue_name=normalized)
 
 
 def _apply_canonical_address(event: Event) -> None:

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -45,8 +45,14 @@ class IsthmusSource(BaseSource):
         # today's events from the scrape window.
         today = datetime.now(_CENTRAL).date()
         end_date = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
+
+        ical_resp = http_get_with_retry(_ICAL_URL, timeout=30)
+        if not ical_resp.content.strip():
+            logger.warning("Isthmus: iCal feed returned empty response; falling back to RSS")
+            return _build_events_from_rss(today, end_date)
+
         url_map, title_date_map = _build_url_map(today, end_date)
-        return _parse_ical(today, end_date, url_map, title_date_map)
+        return _parse_ical(today, end_date, url_map, title_date_map, ical_content=ical_resp.content)
 
 
 def _parse_rss_title(title: str) -> tuple[str, str]:
@@ -116,14 +122,93 @@ def _to_aware_datetime(dt: date | datetime) -> datetime:
     return datetime(dt.year, dt.month, dt.day, tzinfo=_CENTRAL)
 
 
+def _build_events_from_rss(start: date, end: date) -> list[RawEvent]:
+    """Build RawEvents directly from RSS items when the iCal feed is unavailable.
+
+    The RSS occ_dtstart query param includes the local time (e.g. 2026-05-12T19:30)
+    so we can produce properly-timed events without the iCal feed."""
+    events: list[RawEvent] = []
+    page = 1
+    while True:
+        resp = http_get_with_retry(_RSS_BASE, params={"page": page}, timeout=30)
+        if not resp.content.strip():
+            break
+        root = ET.fromstring(resp.content)
+        items = root.findall(".//item")
+        if not items:
+            break
+
+        all_beyond_window = True
+        for item in items:
+            link = item.findtext("link") or ""
+            title_raw = item.findtext("title") or ""
+            qs = parse_qs(urlparse(link).query)
+            occ = qs.get("occ_dtstart", [None])[0]
+            if not occ:
+                continue
+
+            event_date = date.fromisoformat(occ[:10])
+            if event_date <= end:
+                all_beyond_window = False
+            if not (start <= event_date <= end):
+                continue
+
+            # RSS title format: "Event Name - Date [time] [@ Venue]"
+            dash_idx = title_raw.find(" - ")
+            if dash_idx == -1:
+                event_name = title_raw.strip()
+                venue_name = None
+            else:
+                event_name = title_raw[:dash_idx].strip()
+                suffix = title_raw[dash_idx + 3:]
+                at_idx = suffix.rfind(" @ ")
+                venue_name = suffix[at_idx + 3:].strip() if at_idx != -1 else None
+
+            if not event_name:
+                continue
+
+            if "T" in occ:
+                try:
+                    start_at = datetime.fromisoformat(occ).replace(tzinfo=_CENTRAL)
+                    all_day = False
+                except ValueError:
+                    start_at = datetime(event_date.year, event_date.month, event_date.day, tzinfo=_CENTRAL)
+                    all_day = True
+            else:
+                start_at = datetime(event_date.year, event_date.month, event_date.day, tzinfo=_CENTRAL)
+                all_day = True
+
+            description = _fetch_full_description(link)
+            time.sleep(_FETCH_DELAY)
+
+            events.append(RawEvent(
+                title=event_name,
+                start_at=start_at,
+                venue_name=venue_name or None,
+                description=description,
+                source_name="Isthmus",
+                source_url=link,
+                all_day=all_day,
+            ))
+
+        if all_beyond_window:
+            break
+        page += 1
+
+    logger.info("Isthmus RSS fallback: built %d events", len(events))
+    return events
+
+
 def _parse_ical(
     start: date,
     end: date,
     url_map: dict[tuple[str, str, str], str],
     title_date_map: dict[tuple[str, str], str],
+    ical_content: bytes | None = None,
 ) -> list[RawEvent]:
-    resp = http_get_with_retry(_ICAL_URL, timeout=30)
-    cal = Calendar.from_ical(resp.content)
+    if ical_content is None:
+        ical_content = http_get_with_retry(_ICAL_URL, timeout=30).content
+    cal = Calendar.from_ical(ical_content)
 
     events = []
     short_count = enriched_count = failed_count = 0

--- a/backend/app/scrapers/overture.py
+++ b/backend/app/scrapers/overture.py
@@ -42,11 +42,13 @@ and increment year whenever the (month, start_day) regresses vs. the
 previous card. Detail-page schedules already include the year so this
 inference is skipped for enriched events.
 
-Venue handling: the card's room (e.g. "Capitol Theater", "Promenade
-Hall") is left as ``venue_name`` so it dedups cleanly with the
-Ticketmaster scraper's per-room values; the seven Overture-internal
-rooms are added to ``canonical_venues`` so geocoding still resolves to
-the building's coordinates.
+Venue handling: internal sub-rooms (e.g. "Capitol Theater", "Promenade
+Hall") are normalized to "Overture Center for the Arts" by
+``_normalize_venue`` so all Overture events share a single venue_name
+regardless of which room they're in. The same normalization is also
+applied by the ingest layer via ``canonical_venues``, which covers
+Isthmus's "Venue-Subroom" compound format and any other source that
+names a sub-room explicitly.
 """
 
 import logging

--- a/backend/app/scrapers/ticketmaster.py
+++ b/backend/app/scrapers/ticketmaster.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from datetime import date, datetime, time as dtime, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -15,6 +16,23 @@ _WINDOW_DAYS = 30
 _PAGE_SIZE = 200  # Discovery API max
 _PAGE_SLEEP_SECONDS = 0.25  # well under the 5 req/s rate limit
 _DROP_STATUSES: frozenset[str] = frozenset({"cancelled", "postponed"})
+
+# US state code → full lowercase name for canonical URL slug construction.
+_STATE_NAMES: dict[str, str] = {
+    "AL": "alabama", "AK": "alaska", "AZ": "arizona", "AR": "arkansas",
+    "CA": "california", "CO": "colorado", "CT": "connecticut", "DE": "delaware",
+    "FL": "florida", "GA": "georgia", "HI": "hawaii", "ID": "idaho",
+    "IL": "illinois", "IN": "indiana", "IA": "iowa", "KS": "kansas",
+    "KY": "kentucky", "LA": "louisiana", "ME": "maine", "MD": "maryland",
+    "MA": "massachusetts", "MI": "michigan", "MN": "minnesota", "MS": "mississippi",
+    "MO": "missouri", "MT": "montana", "NE": "nebraska", "NV": "nevada",
+    "NH": "new-hampshire", "NJ": "new-jersey", "NM": "new-mexico", "NY": "new-york",
+    "NC": "north-carolina", "ND": "north-dakota", "OH": "ohio", "OK": "oklahoma",
+    "OR": "oregon", "PA": "pennsylvania", "RI": "rhode-island", "SC": "south-carolina",
+    "SD": "south-dakota", "TN": "tennessee", "TX": "texas", "UT": "utah",
+    "VT": "vermont", "VA": "virginia", "WA": "washington", "WV": "west-virginia",
+    "WI": "wisconsin", "WY": "wyoming", "DC": "district-of-columbia",
+}
 
 # Conservative segment/genre → our taxonomy mapping. Lookup order is
 # (segment, genre) first, then (segment, None). Anything unmapped is dropped
@@ -152,6 +170,33 @@ def _map_categories(classifications: list[dict]) -> list[str]:
     return [mapped] if mapped else []
 
 
+def _event_slug(s: str) -> str:
+    s = s.lower()
+    s = re.sub(r"[^a-z0-9\s]", "", s)
+    return re.sub(r"\s+", "-", s.strip())
+
+
+def _build_canonical_url(title: str, event_date: date, venue: dict, event_id: str) -> str | None:
+    """Construct a Ticketmaster canonical event URL from event metadata.
+
+    The Discovery API returns short /event/<id> URLs that fail for some users
+    due to Imperva bot-detection. The full slug URL
+    (/name-city-state-MM-DD-YYYY/event/<id>) is what TM shows in browser
+    address bars and is more reliably resolvable."""
+    if not event_id:
+        return None
+    city = ((venue.get("city") or {}).get("name") or "").strip()
+    state_code = ((venue.get("state") or {}).get("stateCode") or "").strip()
+    if not city or not state_code:
+        return None
+    state_name = _STATE_NAMES.get(state_code, state_code.lower())
+    slug = (
+        f"{_event_slug(title)}-{_event_slug(city)}-{state_name}"
+        f"-{event_date.strftime('%m-%d-%Y')}"
+    )
+    return f"https://www.ticketmaster.com/{slug}/event/{event_id}"
+
+
 def _parse_event(doc: dict) -> RawEvent | None:
     dates = doc.get("dates") or {}
     status = ((dates.get("status") or {}).get("code") or "").strip().lower()
@@ -159,8 +204,7 @@ def _parse_event(doc: dict) -> RawEvent | None:
         return None
 
     title = (doc.get("name") or "").strip()
-    source_url = (doc.get("url") or "").strip()
-    if not title or not source_url:
+    if not title:
         return None
 
     venues = (doc.get("_embedded") or {}).get("venues") or []
@@ -201,6 +245,14 @@ def _parse_event(doc: dict) -> RawEvent | None:
     venue_address = _build_address(venue)
     image_url = _select_image(doc.get("images") or [])
     categories = _map_categories(doc.get("classifications") or [])
+
+    event_id = (doc.get("id") or "").strip()
+    source_url = (
+        _build_canonical_url(title, event_date, venue, event_id)
+        or (doc.get("url") or "").strip()
+    )
+    if not source_url:
+        return None
 
     return RawEvent(
         title=title,


### PR DESCRIPTION
## Summary

- **Venue name normalization** — Isthmus's iCal uses "Overture Center-Overture Hall" while Ticketmaster uses "Overture Center for the Arts"; the exact-match venue filter in fuzzy dedup meant every Overture show had parallel rows per source instead of merging. Added `canonical_name` to `CanonicalVenue` and a `normalize_name()` function; `ingest_events` now normalizes `venue_name` before hashing so all Overture sub-room variants collapse to "Overture Center for the Arts" before dedup runs.
- **Isthmus iCal RSS fallback** — the Isthmus iCal feed is currently returning HTTP 200 with 0 bytes. The scraper now checks for an empty response and falls back to `_build_events_from_rss()`, which uses the RSS `occ_dtstart` param (includes local time, e.g. `2026-05-12T19:30`) to produce properly-timed `RawEvent`s with descriptions fetched from detail pages.
- **Ticketmaster canonical URLs** — the Discovery API returns short `/event/<id>` URLs that 401 for some users due to Imperva bot-detection. The scraper now constructs the full slug URL (`/name-city-state-MM-DD-YYYY/event/<id>`) from event metadata. **Needs browser verification after next scrape** — can't confirm from server-side since TM blocks all non-browser requests regardless of URL format.

## Investigation findings (not fixed here)

The production DB currently has 12 separate B&tB rows — one Ticketmaster row and one Isthmus row per show, none merged. After the next scrape, the venue normalization fix will cause new events to merge correctly. Existing duplicate rows will persist until they age out of the scrape window and get deactivated; no manual cleanup needed.

## Test plan

- [x] `ruff check backend/` passes
- [x] `canonical_venues.normalize_name()` tested against all Overture sub-room variants, compound "Venue-Subroom" format, non-Overture venues, and `None`
- [x] `_normalize_raw_venue()` confirmed to produce matching `canonical_hash` values for Isthmus + Ticketmaster B&tB events at the same time/date
- [x] Fuzzy dedup path verified: after normalization, venue filter matches → substring check fires → ratio 1.0 → merge
- [x] Isthmus RSS fallback tested live against the empty iCal feed; produced 95 events with correct CDT start times and venue names
- [x] TM scraper produces canonical slug URLs for all 8 B&tB shows
- [ ] Verify TM canonical URLs work when clicked in a browser (after next scrape deploys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)