### PR TITLE
Fix iPhone map view: "events without a location" panel overflowed footer

### DIFF
--- a/frontend/src/components/MapView.jsx
+++ b/frontend/src/components/MapView.jsx
@@ -76,7 +76,7 @@ export default function MapView({ events, stickyTop = 0, fillHeight = false }) {
   )
 
   const mapContainerStyle = fillHeight
-    ? { flex: 1, minHeight: '400px' }
+    ? { flex: 1, minHeight: 0 }
     : { height: `calc(100vh - ${stickyTop + 32}px)`, minHeight: '400px' }
 
   return (
@@ -119,7 +119,7 @@ export default function MapView({ events, stickyTop = 0, fillHeight = false }) {
             {noLocEvents.length} event{noLocEvents.length === 1 ? '' : 's'} without a location {showNoLoc ? '▲' : '▼'}
           </button>
           {showNoLoc && (
-            <ul className="mt-2 space-y-1">
+            <ul className="mt-2 space-y-1 overflow-y-auto" style={{ maxHeight: '40vh' }}>
               {noLocEvents.map(e => (
                 <li key={e.id}>
                   <button


### PR DESCRIPTION
## Summary
- Fixes an iPhone map-view bug reported with a screenshot: tapping "N events without a location" expanded a list that couldn't be scrolled and whose bottom ran past the viewport, visually covering the page footer.
- Two changes in `frontend/src/components/MapView.jsx`:
  - Add `overflow-y-auto` + `maxHeight: 40vh` to the expanded `<ul>` so long lists scroll internally.
  - Drop the map container's `minHeight: 400px` in `fillHeight` mode so the map shrinks via `flex: 1` to make room for the panel. The non-fillHeight branch (used when MapView isn't filling the page) keeps the 400px floor.

## Test plan
- [x] Open the dev server in a mobile-sized viewport (or real iPhone), switch to Map view, expand the "events without a location" panel.
- [x] Confirm the list scrolls inside the amber panel.
- [x] Confirm the footer ("Open source · Submit feedback · Icon by Loren Klein…") remains visible below the panel and isn't overlapped.
- [x] Switch back to List view; confirm the map height in list-view contexts (if any) is unaffected — the 400px floor still applies in the non-fillHeight branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)