### PR TITLE
Add /audit-event-accuracy skill for ingest QA (closes #170)

### DIFF
--- a/.claude/skills/audit-event-accuracy/SKILL.md
+++ b/.claude/skills/audit-event-accuracy/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: audit-event-accuracy
+description: This skill should be used when the user asks to "audit event accuracy", "spot-check ingest quality", "audit the events database", "check if scrapers got events right", or wants to verify that titles, dates, venues, descriptions, and categories in production match the primary source pages. Samples events across every integrated source, fetches each event's source URL(s), compares fields, evaluates whether SOURCE_PRIORITY ranks the richest sources highest, and files GitHub issues for each finding.
+---
+
+# Audit Event Accuracy
+
+Audit production ingest quality for What's Up Madison by sampling events from the live API, fetching their primary-source pages, and comparing what was ingested against what the source actually publishes. File one GitHub issue per finding so individual defects can be triaged and closed independently.
+
+The audit has two distinct goals:
+
+1. **Field accuracy.** Verify that title, start/end times, venue name & address, description, categories, and image URL match the highest-priority source page.
+2. **Source-priority sanity.** For multi-source events, judge whether `SOURCE_PRIORITY` (defined in `frontend/src/lib/sources.js` and mirrored in `backend/app/ingest.py`) ranks the richest sources first. If a lower-priority source consistently carries better data than the current top source, propose a re-ranking.
+
+All work runs against the **production deployment** at `https://whats-up-madison.fly.dev` — that's the data users see, and the only thing worth auditing.
+
+## Workflow
+
+### 1. Sample events
+
+Run the bundled sampler against production:
+
+```bash
+python .claude/skills/audit-event-accuracy/scripts/sample_events.py --per-source 3
+```
+
+The script fetches `GET /events?date=` for 7 forward dates spread across the next 14 days, deduplicates by event ID, buckets events by their primary source, and emits JSONL on stdout — one line per sampled event. Each record carries `id`, `title`, `start_at`, `end_at`, `all_day`, `venue_name`, `venue_address`, `categories`, `image_url`, the full `sources` array, a 500-char `description_preview`, and a `description_truncated` flag.
+
+Flags:
+- `--per-source N` — sample size per source (default 3, ~18 events total).
+- `--base-url URL` — override the API base (default `https://whats-up-madison.fly.dev`).
+- `--seed S` — deterministic sampling for reproducible runs.
+
+Stderr carries fetch errors (with a `# fetch error:` prefix) and a final `# summary: {...}` line listing how many events were available per source.
+
+### 2. Audit each sampled event
+
+For every JSONL record:
+
+1. **Fetch every source URL on the event** using WebFetch — not just the highest-priority one. Sources that 4xx/5xx or that have no URL are noted in the finding but do not fail the audit.
+2. **Build a per-source observation** of the fields visible on each source page: title, calendar date (in `America/Chicago`), start time (when not all-day), venue name & address, description body, source-declared categories or tags, image presence.
+3. **Field-accuracy check.** Compare the stored `Event` against the **highest-priority source's page** (per `SOURCE_PRIORITY` — order: High Noon Saloon, Atwood Music Hall, Ticketmaster, Our Lives, Isthmus, Visit Madison). Apply these rules:
+   - **Title:** substring match in either direction is acceptable (the source may include "presented by …" decorations).
+   - **Date:** calendar day must match in `America/Chicago`.
+   - **Start time:** must match within 5 minutes when `all_day` is false.
+   - **Venue name & address:** must be the same physical place. Allow alias differences (e.g., "Overture Center for the Arts" vs "Overture Hall") — these are intentional canonicalization, not bugs.
+   - **Description:** do not flag for short descriptions (some sources just have little to say). Do flag descriptions that appear truncated mid-sentence, contain raw HTML, or are dominated by boilerplate / cookie banners.
+   - **Categories:** LLM-tagged categories should be plausible given the source content; source-supplied taxonomies (Isthmus, Visit Madison, Ticketmaster) should be reflected. Missing the obvious category (e.g., a music concert tagged as nothing) is flag-worthy; debating between two plausible tags is not.
+   - **Image:** flag only if the source clearly has a hero image and the ingested event has none.
+4. **Source-priority sanity check.** Only relevant for multi-source events. Qualitatively rank each source page by data richness. Weight these dimensions roughly equally (it's a judgment, not a precise score):
+   - description length and specificity (2x)
+   - structured fields present (explicit start/end times, venue address, ticket info) (2x)
+   - accurate venue + address (1x)
+   - source-supplied categories or tags (1x)
+   - hero image / visual context (1x)
+   - **negative:** boilerplate, paywall, ticket-funnel cruft, missing data (1x)
+
+   If a source ranked **lower** in `SOURCE_PRIORITY` looks materially richer than the current top source (clear difference, not a wash), flag it for a priority-ordering review. Borderline calls — skip; only file when the recommendation is clearly correct.
+
+### 3. File findings as GitHub issues
+
+Two finding kinds, two issue templates. Create the label first if needed:
+
+```bash
+gh label create accuracy-audit --color BFD4F2 --description "Findings from /audit-event-accuracy" 2>/dev/null || true
+```
+
+#### Field-accuracy issues (one per event × failing field)
+
+**Dedup first.** A finding with the same event ID and the same finding kind on an open issue means we've already filed it.
+
+```bash
+gh issue list --label accuracy-audit --state open --json number,title,body \
+  --jq '.[] | select(.body | contains("<event-id>") and contains("field-accuracy"))'
+```
+
+If empty, file:
+
+```bash
+gh issue create \
+  --label accuracy-audit \
+  --title "Audit: <field> mismatch on '<event title>'" \
+  --body "$(cat <<'EOF'
+**Kind:** field-accuracy
+**Event ID:** <uuid>
+**Field:** <title|start_at|end_at|venue_name|venue_address|description|categories|image_url>
+**Primary source:** <Source Name> — <source_url>
+**Other sources:** <list, if any>
+
+**Source page shows:** <what the source actually says>
+**Ingested as:** <what's in the DB>
+
+**Hypothesis:** <one line — e.g. "Visit Madison description appears truncated at character 500; check Simpleview API response handling.">
+
+API: https://whats-up-madison.fly.dev/events?date=<YYYY-MM-DD>
+EOF
+)"
+```
+
+#### Source-priority issues (one per source pair, append events on repeat)
+
+**Dedup by source-pair, not by event ID.** Many events can share the same priority recommendation — they should pile into one issue. The dedup query is by title:
+
+```bash
+gh issue list --label accuracy-audit --state open --json number,title,body \
+  --jq '.[] | select(.title == "Audit: review SOURCE_PRIORITY for <higher> vs <lower>")'
+```
+
+If no open issue exists, create one:
+
+```bash
+gh issue create \
+  --label accuracy-audit \
+  --title "Audit: review SOURCE_PRIORITY for <higher> vs <lower>" \
+  --body "$(cat <<'EOF'
+**Kind:** source-priority
+**Current ranking:** <higher> is preferred over <lower> per SOURCE_PRIORITY
+**Observation:** <lower> consistently provides richer event data than <higher> in the sample below. Consider swapping these in `SOURCE_PRIORITY` (defined in both `frontend/src/lib/sources.js` and `backend/app/ingest.py` — keep them in sync).
+
+## Example events
+
+### <event title> (<event-id>)
+- <higher> (<higher-url>): <brief data summary>
+- <lower> (<lower-url>): <brief data summary>
+- Verdict: <one line on why lower is richer>
+
+EOF
+)"
+```
+
+If an open issue already exists for the pair, **append** the new example to its body. Use `gh issue view <n> --json body --jq .body` to read, append the new example block, then write back. The CLAUDE.md gotcha says `gh issue edit --body` and `--body-file` may silently fail; fall back to the API:
+
+```bash
+gh api repos/<owner>/<name>/issues/<n> --method PATCH --field body="$NEW_BODY"
+```
+
+(Use `gh repo view --json nameWithOwner --jq .nameWithOwner` to get owner/name.)
+
+### 4. Print a summary
+
+After processing all sampled events, output one line per source:
+
+```
+Isthmus: 3 audited, 1 field-mismatch, 0 priority concerns, 1 issue filed, 0 duplicates skipped
+Visit Madison: 3 audited, 0 field-mismatches, 1 priority concern, 1 issue filed (appended to existing pair issue)
+…
+```
+
+## Conventions and gotchas
+
+- `SOURCE_PRIORITY` is mirrored in two places — `frontend/src/lib/sources.js` and `backend/app/ingest.py`. Any priority-related issue body must call this out so whoever fixes it updates both.
+- The events API returns `start_at` and `end_at` in UTC; convert to `America/Chicago` before comparing to a source page's "Saturday, May 17" rendering.
+- Some sources (Visit Madison, Our Lives) have all-day recurring entries — those don't have a meaningful "time" to verify; skip the start-time comparison when `all_day` is true.
+- WebFetch may return partial pages (paywall walls, JS-heavy sites). If a fetch returns an obviously truncated body, note it in the finding but don't speculate about field mismatches from incomplete data.
+- Don't open priority issues on a single example. Only file when at least two events in the sample show the same lower-vs-higher disparity, **or** when the disparity is dramatic on a single event (e.g., one source has a full event description and the other returns 404).
+
+## Files
+
+- **`scripts/sample_events.py`** — fetches and emits the JSONL sample. Stdlib only.

--- a/.claude/skills/audit-event-accuracy/scripts/sample_events.py
+++ b/.claude/skills/audit-event-accuracy/scripts/sample_events.py
@@ -1,0 +1,140 @@
+"""Sample events from production for the /audit-event-accuracy skill.
+
+Hits the public /events?date= endpoint for a spread of forward dates, buckets
+events by their first source, and emits JSONL on stdout — one line per sampled
+event. Stdlib only so it runs anywhere without conda.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import random
+import sys
+import urllib.error
+import urllib.request
+
+_DEFAULT_BASE = "https://whats-up-madison.fly.dev"
+# Offsets (in days) from today to sample. Spread across two weeks so we hit
+# different days of the week and both near- and far-horizon ingest behavior
+# without sampling every consecutive day.
+_DATE_OFFSETS = (0, 2, 4, 6, 8, 11, 14)
+_DESCRIPTION_PREVIEW = 500
+
+
+def _fetch_date(base_url: str, date: datetime.date) -> list[dict]:
+    url = f"{base_url.rstrip('/')}/events?date={date.isoformat()}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def _primary_source(event: dict) -> str | None:
+    sources = event.get("sources") or []
+    if not sources:
+        return None
+    return sources[0].get("source_name")
+
+
+def _trim_description(desc: str | None) -> tuple[str | None, bool]:
+    if not desc:
+        return desc, False
+    if len(desc) <= _DESCRIPTION_PREVIEW:
+        return desc, False
+    return desc[:_DESCRIPTION_PREVIEW], True
+
+
+def _pick_varied(events: list[dict], n: int, rng: random.Random) -> list[dict]:
+    """Pick up to `n` events biased toward variety in venue and start date."""
+    if len(events) <= n:
+        return events
+    rng.shuffle(events)
+    picked: list[dict] = []
+    seen_venues: set[str] = set()
+    seen_dates: set[str] = set()
+    # First pass: prefer fresh venue + date combos.
+    for event in events:
+        if len(picked) >= n:
+            break
+        venue = (event.get("venue_name") or "").lower()
+        date = (event.get("start_at") or "")[:10]
+        if venue in seen_venues and date in seen_dates:
+            continue
+        seen_venues.add(venue)
+        seen_dates.add(date)
+        picked.append(event)
+    # Top up with whatever remains if variety constraint left us short.
+    if len(picked) < n:
+        for event in events:
+            if event in picked:
+                continue
+            picked.append(event)
+            if len(picked) >= n:
+                break
+    return picked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--per-source", type=int, default=3, help="events to sample per source (default 3)")
+    parser.add_argument("--base-url", default=_DEFAULT_BASE, help=f"API base URL (default {_DEFAULT_BASE})")
+    parser.add_argument("--seed", type=int, default=None, help="optional RNG seed for deterministic sampling")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+    today = datetime.date.today()
+
+    by_id: dict[str, dict] = {}
+    fetch_errors: list[str] = []
+    for offset in _DATE_OFFSETS:
+        date = today + datetime.timedelta(days=offset)
+        try:
+            events = _fetch_date(args.base_url, date)
+        except (urllib.error.URLError, TimeoutError) as exc:
+            fetch_errors.append(f"{date.isoformat()}: {exc}")
+            continue
+        for event in events:
+            event_id = event.get("id")
+            if event_id and event_id not in by_id:
+                by_id[event_id] = event
+
+    if fetch_errors:
+        for err in fetch_errors:
+            print(f"# fetch error: {err}", file=sys.stderr)
+
+    buckets: dict[str, list[dict]] = {}
+    for event in by_id.values():
+        src = _primary_source(event) or "(no source)"
+        buckets.setdefault(src, []).append(event)
+
+    for source in sorted(buckets):
+        events = buckets[source]
+        sampled = _pick_varied(events, args.per_source, rng)
+        for event in sampled:
+            desc, truncated = _trim_description(event.get("description"))
+            record = {
+                "id": event.get("id"),
+                "title": event.get("title"),
+                "start_at": event.get("start_at"),
+                "end_at": event.get("end_at"),
+                "all_day": event.get("all_day", False),
+                "venue_name": event.get("venue_name"),
+                "venue_address": event.get("venue_address"),
+                "categories": event.get("categories", []),
+                "description_preview": desc,
+                "description_truncated": truncated,
+                "image_url": event.get("image_url"),
+                "sources": event.get("sources", []),
+                "primary_source": source,
+                "pool_size_for_source": len(events),
+            }
+            print(json.dumps(record, ensure_ascii=False))
+
+    summary = {src: {"available": len(buckets[src]), "sampled": min(len(buckets[src]), args.per_source)} for src in buckets}
+    print(f"# summary: {json.dumps(summary, ensure_ascii=False)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,9 @@ frontend/.wrangler/
 # Local machine-specific
 local_management/
 .claude_scripts/
-.claude/
+# Per-user Claude Code settings stay local; project-shared skills are checked in.
+.claude/*
+!.claude/skills/
 
 # OS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,12 @@ npm run build    # production build
 ~/miniconda3/envs/whats-up-madison/bin/ruff check backend/
 ```
 
+## Skills
+
+Project-local Claude Code skills live in `.claude/skills/`. Each skill is a directory with a `SKILL.md` and any bundled scripts/references. They are auto-discovered when working in this repo with Claude Code.
+
+- **`audit-event-accuracy`** — samples events from the production API, fetches each event's source URL(s), and files GitHub issues for two kinds of finding: (1) field-accuracy mismatches between ingested data and the primary-source page, and (2) source-priority concerns where a lower-trust source has materially richer data than the higher-trust one. Issues are labeled `accuracy-audit` and deduped by event ID (field-accuracy) or source-pair (priority). Invoke with `/audit-event-accuracy`.
+
 ## Triggering a Scrape (Dev)
 
 **Default to targeted runs when iterating on scraper code.** A full no-arg `/admin/scrape` runs all seven sources, geocodes everything new via Nominatim, then runs the LLM tagger over every untagged event — multiple minutes plus real Anthropic + OSM spend. Most scraper changes only need to verify one source's `fetch()` output, so pass `?scraper=<name>&days=<small N>&skip_geocode=true&skip_tag=true` and drop the flags only for end-to-end checks or the scheduled job.


### PR DESCRIPTION
Closes #170.

Adds the first project-local Claude Code skill at `.claude/skills/audit-event-accuracy/`. It samples production events across every integrated source, fetches each event's source URL(s), and files focused GitHub issues for ingest defects. Two kinds of finding:

- **`field-accuracy`** — title / date / venue / description / categories / image mismatch between the stored event and the highest-priority source page. One issue per event × failing field, deduped on event ID.
- **`source-priority`** — multi-source events where a lower-trust source has materially richer data than the higher-trust one, suggesting the `SOURCE_PRIORITY` ranking (`frontend/src/lib/sources.js` + `backend/app/ingest.py`) should be re-ordered. One issue per source-pair; repeat runs append example event IDs rather than opening duplicates.

Issues are tagged `accuracy-audit`. The skill creates the label on first run if it's missing.

## Files

- **New** `.claude/skills/audit-event-accuracy/SKILL.md` — full audit workflow, dedup queries, issue templates.
- **New** `.claude/skills/audit-event-accuracy/scripts/sample_events.py` — stdlib-only sampler that hits `/events?date=` for 7 dates spread across the next 14 days, buckets by primary source, picks N per source (default 3) biased toward varied venues + dates. Emits JSONL.
- **Edit** `.gitignore` — `.claude/*` ignored except `.claude/skills/`, so project-shared skills are checked in while per-user `.claude/settings.local.json` stays out.
- **Edit** `AGENTS.md` — new `## Skills` section documenting `audit-event-accuracy`.

## Verification

- [x] `ruff check .claude/skills/audit-event-accuracy/scripts/sample_events.py` passes.
- [x] Sampler runs end-to-end against prod (`--per-source 2 --seed 42` → 12 events, all 6 sources represented: Visit Madison, Isthmus, Our Lives, Ticketmaster, High Noon Saloon, Atwood Music Hall).
- [x] Multi-source event check: Pert Near Sandstone has 3 sources (High Noon 200, Ticketmaster 401 bot-block, Visit Madison 200) — confirms the skill's "fetch every source, note unreachable ones" path is exercised by real data.
- [x] `accuracy-audit` label created on the repo with the documented color and description.
- [x] Dedup query (`gh issue list --label accuracy-audit --state open --jq '… contains("<id>") …'`) returns clean for a fake event ID.
- [x] SKILL.md frontmatter has third-person `description` with explicit trigger phrases; body is in imperative form.
- [x] CI scope check: `.github/workflows/ci.yml` lints only `backend/` and `frontend/` — nothing touches `.claude/`, no CI risk from the new files.
- [ ] Invoke `/audit-event-accuracy` in a fresh Claude Code session and confirm it loads, runs the sampler, audits at least one multi-source event, and produces sensible issue drafts. Spot-check the body format of one filed issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)