### PR TITLE
Drop venue-policy boilerplate from Ticketmaster descriptions

### DIFF
--- a/backend/app/scrapers/ticketmaster.py
+++ b/backend/app/scrapers/ticketmaster.py
@@ -17,6 +17,110 @@ _PAGE_SIZE = 200  # Discovery API max
 _PAGE_SLEEP_SECONDS = 0.25  # well under the 5 req/s rate limit
 _DROP_STATUSES: frozenset[str] = frozenset({"cancelled", "postponed"})
 
+# Minimum residual length after stripping venue boilerplate to treat the field
+# as carrying event-specific signal. TM populates info/pleaseNote with templated
+# venue-policy copy (cashless, bag policy, ADA seating contact, door times) that
+# repeats across every show at a venue; below this threshold the residue is
+# noise (e.g. just punctuation or fragments), so we surface no description and
+# let downstream higher-priority sources fill it via the ingest merge.
+_DESCRIPTION_MIN_SIGNAL_LENGTH = 40
+
+# Patterns covering the templated venue-policy phrases that TM ships in
+# info/pleaseNote. Each matches a single sentence/clause so the residue test
+# is "how much *non-boilerplate* text remains" rather than "is the whole
+# field one of N known strings". The set was derived from a survey of every
+# unique sentence across info+pleaseNote on the live Madison TM feed; new
+# variants should be added here as they show up in the audit.
+_BOILERPLATE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        # Door / show times prefix — variants seen: "Doors at 7:00 pm",
+        # "Doors at 7:00 pm | Show at 8:00 pm", "Doors open at 6:00 pm",
+        # "Doors at 8: 00 pm | Show at 9:00 pm" (TM occasionally injects spaces).
+        r"Doors?\s+(?:open(?:s|ed)?\s+)?at\s+\d{1,2}\s*:?\s*\d{2}\s?[ap]m\s*"
+        r"(?:\|\s*Shows?\s+at\s+\d{1,2}\s*:?\s*\d{2}\s?[ap]m\s*)?",
+        # Cashless venue policy
+        r"CASHLESS\s+VENUE[^.]*(?:\.|$)",
+        r"No\s+cash\s+accepted\.",
+        # Bag policy
+        r"Bags?\s*\(max\s+size[^)]+\)[^.]*(?:\.|$)",
+        r"Exceptions\s+will\s+be\s+made\s+for\s+necessary\s+medical[^.]*(?:\.|$)",
+        r"We\s+encourage\s+you\s+to\s+pack\s+light[^.]*(?:\.|$)",
+        # General-admission seating — Sylvee/Majestic/Orpheum variants:
+        #  - "All General Admission Tickets are good for the standing GA Floor..."
+        #  - "All General Admission tickets are seated."
+        #  - "All tickets are standing and seated General Admission and are
+        #    available on a first come first serve basis."
+        r"All\s+General\s+Admission\s+[Tt]ickets?\s+are\s+(?:good\s+for|seated)[^.]*(?:\.|$)",
+        r"All\s+tickets\s+are\s+(?:standing|seated)[^.]*"
+        r"(?:General\s+Admission|first\s+come\s+first\s+serve)[^.]*(?:\.|$)",
+        r"They\s+are\s+available\s+on\s+a\s+first\s+come\s+first\s+serve\s+basis\.",
+        # Orpheum tiered-GA-pricing boilerplate
+        r"A\s+tiered\s+system\s+is\s+in\s+place\s+for\s+General\s+Admission[^.]*(?:\.|$)",
+        r"This\s+allows\s+us\s+to\s+reward\s+the\s+most\s+loyal\s+fans[^.]*(?:\.|$)",
+        r"Prices\s+will\s+increase\s+as\s+each\s+tier\s+sells\s+out\.",
+        r"Every\s+General\s+Admission\s+ticket[^.]*(?:\.|$)",
+        # Majestic Opera Boxes accessibility note
+        r"The\s+Opera\s+Boxes\s+are\s+only\s+accessible\s+by\s+stairs\.",
+        # ADA / accessible seating — "Accessible Seating: Accessible seating
+        # is available..." and the shorter "Accessible Seating: Available..."
+        r"Accessible\s+Seating:\s*(?:Accessible\s+seating\s+is\s+available|Available)[^.]*(?:\.|$)",
+        r"For\s+additional\s+information\s+call\s+[\d\s\-]+\.",
+        # Theatre/Theater accessibility note (both spellings appear in the feed).
+        r"There\s+are\s+no\s+elevators\s+in\s+the\s+[Tt]heat(?:re|er)\.",
+        # Box-office / re-purchase variants — covers "Advance tickets can be
+        # purchased online or at The Sylvee box office.", "Tickets can be
+        # purchased online up to the event start time.", and "Once the doors
+        # have opened, if tickets are still available, they can be purchased
+        # at the <venue>." / "Once the event has started, if tickets are still
+        # available, they can be purchased at the Sylvee box office."
+        r"(?:Advance\s+)?Tickets\s+can\s+be\s+purchased[^.]*(?:\.|$)",
+        r"Once\s+the\s+(?:doors?\s+(?:have\s+)?opened|event\s+has\s+started)[^.]*(?:\.|$)",
+        # Age restriction noise (also appears mid-sentence)
+        r"Ages?\s+\d+\+",
+        # Cancellation placeholder TM sometimes leaves on cancelled events
+        r"Unfortunately,\s+the\s+Event\s+Organizer\s+has\s+had\s+to\s+cancel\s+your\s+event\.",
+    )
+)
+
+
+def _scrub_boilerplate(text: str) -> str:
+    """Strip well-known TM/venue boilerplate phrases and return the residue.
+
+    Only the gating decision in :func:`_choose_description` consults the
+    residue; the value stored on ``RawEvent.description`` is the *original*
+    raw text, so mixed descriptions (door-times prefix + real event copy)
+    survive verbatim. Whitespace and stray punctuation left behind after a
+    strip are normalised so a residue of ", . :" doesn't beat the threshold.
+    """
+    for pat in _BOILERPLATE_PATTERNS:
+        text = pat.sub(" ", text)
+    # Collapse runs of orphan punctuation that strips leave behind (e.g.
+    # ". . . ." between consecutive scrubbed sentences) so they don't inflate
+    # the residue length above the signal threshold.
+    text = re.sub(r"(?:\s*[.,;:|\-]+\s*){2,}", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"^[\s\.,:;|\-]+|[\s\.,:;|\-]+$", "", text)
+    return text
+
+
+def _choose_description(info: str | None, please_note: str | None) -> str | None:
+    """Pick the best event description from TM ``info``/``pleaseNote``.
+
+    Returns the raw ``info`` (or ``pleaseNote`` fallback) when it carries
+    enough event-specific signal after boilerplate is conceptually removed;
+    otherwise returns ``None`` so a higher-priority source (Isthmus, Visit
+    Madison) can fill the field via ingest's source-priority merge, or so
+    the frontend simply renders no description.
+    """
+    for candidate in (info, please_note):
+        raw = (candidate or "").strip()
+        if not raw:
+            continue
+        if len(_scrub_boilerplate(raw)) >= _DESCRIPTION_MIN_SIGNAL_LENGTH:
+            return raw
+    return None
+
 # US state code → full lowercase name for canonical URL slug construction.
 _STATE_NAMES: dict[str, str] = {
     "AL": "alabama", "AK": "alaska", "AZ": "arizona", "AR": "arkansas",
@@ -239,7 +343,7 @@ def _parse_event(doc: dict) -> RawEvent | None:
         end_time = _parse_local_time(end_block.get("localTime")) or dtime.max
         end_at = datetime.combine(end_date, end_time, tzinfo=tz)
 
-    description = (doc.get("info") or doc.get("pleaseNote") or "").strip() or None
+    description = _choose_description(doc.get("info"), doc.get("pleaseNote"))
 
     venue_name = (venue.get("name") or "").strip() or None
     venue_address = _build_address(venue)

--- a/backend/tests/test_ticketmaster.py
+++ b/backend/tests/test_ticketmaster.py
@@ -5,9 +5,67 @@ from zoneinfo import ZoneInfo
 from app.scrapers.ticketmaster import (
     _CENTRAL,
     _build_address,
+    _choose_description,
     _map_categories,
     _parse_event,
     _select_image,
+)
+
+
+# Literal venue boilerplate copy harvested from the Discovery API responses
+# that drove audit issues #177 (Rebirth Brass Band) and #178 (Highly Suspect).
+# Asserting these collapse to ``None`` is the regression for both findings.
+_SYLVEE_BOILERPLATE = (
+    "Doors at 6:00 pm | Show at 7:30 pm CASHLESS VENUE - The Sylvee services all credit "
+    "and debit payments only. No cash accepted. Bags (max size 12\" x 6\" x 12\") are "
+    "allowed and will be searched upon entry. Exceptions will be made for necessary "
+    "medical equipment and bags for nursing mothers. We encourage you to pack light "
+    "with only the necessities to make the entry process as smooth as possible. All "
+    "General Admission Tickets are good for the standing General Admission Floor and "
+    "GA Balcony areas on a first come first serve basis. Accessible Seating: "
+    "Accessible seating is available online through Ticketmaster by filtering on the "
+    "ADA Icon and selecting the Accessible Seats, or in person at The Sylvee Box "
+    "Office during business hours. For additional information call 608-709-8157."
+)
+_MAJESTIC_BOILERPLATE = (  # literal info field on the Rebirth Brass Band event (#177)
+    "Doors at 7:00 pm | Show at 8:00 pm CASHLESS VENUE - The Majestic Theatre services "
+    "all credit and debit payments only. No cash accepted. Bags (max size 12\" x 6\" x "
+    "12\") are allowed and will be searched upon entry. Exceptions will be made for "
+    "necessary medical equipment and bags for nursing mothers. We encourage you to "
+    "pack light with only the necessities to make the entry process as smooth as "
+    "possible. All tickets are standing and seated General Admission and are available "
+    "on a first come first serve basis. The Opera Boxes are only accessible by stairs. "
+    "Advance tickets can be purchased online or at The Sylvee box office. Once the "
+    "doors have opened, if tickets are still available, they can be purchased at the "
+    "Majestic Theatre."
+)
+# pleaseNote variants — TM ships these in parallel with info, with slightly
+# different wording ("Doors open at 6:00 pm." vs "Doors at 6:00 pm | Show at 7:30 pm",
+# "Once the event has started" vs "Once the doors have opened"). Both must scrub.
+_SYLVEE_PLEASE_NOTE = (
+    "Doors open at 6:00 pm. CASHLESS VENUE - The Sylvee services all credit and debit "
+    "payments only. No cash accepted. Bags (max size 12\" x 6\" x 12\") are allowed and "
+    "will be searched upon entry. Exceptions will be made for necessary medical "
+    "equipment and bags for nursing mothers. We encourage you to pack light with only "
+    "the necessities to make the entry process as smooth as possible. Tickets can be "
+    "purchased online up to the event start time. Once the event has started, if "
+    "tickets are still available, they can be purchased at the Sylvee box office."
+)
+_BARRYMORE_BOILERPLATE = (
+    "Doors at 7:00 pm | Show at 8:00 pm There are no elevators in the theatre. "
+    "Advance tickets can be purchased online or at The Sylvee box office. Once the "
+    "doors have opened, if tickets are still available, they can be purchased at the "
+    "venue."
+)
+_BARRYMORE_LOWERCASE_THEATER = (  # the feed has both "theatre" and "theater" spellings
+    "Doors at 7:00 pm | Show at 8:00 pm There are no elevators in the theater. "
+    "Advance tickets can be purchased online or at The Sylvee box office."
+)
+_RENT_REAL_DESCRIPTION = (
+    "This season, we proudly celebrate the 30th anniversary of RENT, the groundbreaking "
+    "musical that redefined Broadway and continues to inspire audiences worldwide. "
+    "Capital City Theatre is thrilled to present a fresh staging of Jonathan Larson's "
+    "iconic work."
 )
 
 
@@ -35,7 +93,11 @@ def _doc(
     end_time=None,
     status="onsale",
     timezone="America/Chicago",
-    info="Doors at 6:30 pm | Show at 8:00 pm. Cashless venue, bag policy applies.",
+    info=(
+        "Modest Mouse return with their first headline tour in support of the band's "
+        "ninth studio album, joined by a rotating lineup of special guests across the "
+        "summer of 2026."
+    ),
     please_note=None,
     venue=None,
     images=None,
@@ -221,7 +283,8 @@ class TestParseEvent:
         assert ev.all_day is False
         assert ev.venue_name == "The Sylvee"
         assert ev.venue_address == "25 S. Livingston Street, Madison, WI 53703"
-        assert ev.description.startswith("Doors at 6:30 pm")
+        assert ev.description is not None
+        assert ev.description.startswith("Modest Mouse return")
         assert ev.image_url == "https://img/large.jpg"
         assert ev.categories == ["Music"]
         assert ev.source_name == "Ticketmaster"
@@ -293,12 +356,32 @@ class TestParseEvent:
         assert _parse_event(doc) is None
 
     def test_description_falls_back_to_please_note(self):
-        ev = _parse_event(_doc(info=None, please_note="Bag policy in effect."))
+        # info absent → fall back to pleaseNote when it carries real signal.
+        ev = _parse_event(_doc(
+            info=None,
+            please_note=(
+                "Free meet-and-greet with the artist runs in the lobby from 7-7:45pm "
+                "for VIP ticket holders only."
+            ),
+        ))
         assert ev is not None
-        assert ev.description == "Bag policy in effect."
+        assert ev.description is not None
+        assert ev.description.startswith("Free meet-and-greet")
+
+    def test_description_none_when_please_note_is_boilerplate(self):
+        # Both fields populated but pleaseNote is venue boilerplate → no description.
+        ev = _parse_event(_doc(info=None, please_note=_SYLVEE_BOILERPLATE))
+        assert ev is not None
+        assert ev.description is None
 
     def test_description_none_when_both_missing(self):
         ev = _parse_event(_doc(info=None, please_note=None))
+        assert ev is not None
+        assert ev.description is None
+
+    def test_description_none_when_info_is_venue_boilerplate(self):
+        # Regression for #178 (Highly Suspect at The Sylvee).
+        ev = _parse_event(_doc(info=_SYLVEE_BOILERPLATE, please_note=None))
         assert ev is not None
         assert ev.description is None
 
@@ -332,3 +415,93 @@ class TestParseEvent:
         assert ev.end_at is not None
         assert ev.end_at.date().isoformat() == "2026-10-01"
         assert ev.end_at.time() == dtime.max
+
+
+# ---------------------------------------------------------------------------
+# _choose_description
+# ---------------------------------------------------------------------------
+
+class TestChooseDescription:
+    """Gating logic for the description field.
+
+    TM ships per-venue policy boilerplate in info/pleaseNote; the helper
+    must surface real event copy and drop pure boilerplate so audit issues
+    #177 and #178 don't recur.
+    """
+
+    def test_pure_sylvee_boilerplate_returns_none(self):
+        # Regression for #178.
+        assert _choose_description(_SYLVEE_BOILERPLATE, None) is None
+
+    def test_pure_majestic_boilerplate_returns_none(self):
+        # Regression for #177.
+        assert _choose_description(_MAJESTIC_BOILERPLATE, None) is None
+
+    def test_pure_barrymore_boilerplate_returns_none(self):
+        assert _choose_description(_BARRYMORE_BOILERPLATE, None) is None
+
+    def test_barrymore_lowercase_theater_spelling_returns_none(self):
+        # The feed has both "theatre" and "theater" — must scrub both.
+        assert _choose_description(_BARRYMORE_LOWERCASE_THEATER, None) is None
+
+    def test_sylvee_please_note_variant_returns_none(self):
+        # The other observed regression: pleaseNote ships the same boilerplate
+        # with different wording ("Doors open at" / "Once the event has started").
+        assert _choose_description(None, _SYLVEE_PLEASE_NOTE) is None
+
+    def test_orpheum_tiered_ga_boilerplate_returns_none(self):
+        # Observed on Orpheum events that ship the tiered-GA-pricing block.
+        tiered = (
+            "Doors at 7:00 pm | Show at 8:00 pm A tiered system is in place for "
+            "General Admission tickets. This allows us to reward the most loyal fans "
+            "who buy early by giving them access to the lowest priced tickets. Prices "
+            "will increase as each tier sells out. Every General Admission ticket "
+            "(regardless of tier) will have the same access and benefits at the show."
+        )
+        assert _choose_description(tiered, None) is None
+
+    def test_empty_inputs_return_none(self):
+        assert _choose_description(None, None) is None
+        assert _choose_description("", "") is None
+        assert _choose_description("   ", "\n\t") is None
+
+    def test_real_event_description_kept_verbatim(self):
+        assert _choose_description(_RENT_REAL_DESCRIPTION, None) == _RENT_REAL_DESCRIPTION
+
+    def test_cancellation_placeholder_dropped(self):
+        # TM occasionally swaps the info field on cancelled events for this
+        # boilerplate placeholder. Drop it so we don't render it as a description.
+        assert _choose_description(
+            "Unfortunately, the Event Organizer has had to cancel your event.",
+            None,
+        ) is None
+
+    def test_doortime_prefix_with_real_copy_preserved_verbatim(self):
+        # Mixed input — boilerplate prefix + real artist copy. The original
+        # raw string is returned (we only use scrubbing to decide whether to
+        # keep it), so the door times survive too.
+        mixed = (
+            "Doors at 6:00 pm | Show at 7:00 pm Cary Elwes (Westley) is hitting "
+            "the road to share never-before-told stories from the making of The "
+            "Princess Bride, followed by a screening and live Q&A."
+        )
+        assert _choose_description(mixed, None) == mixed
+
+    def test_info_empty_falls_back_to_please_note(self):
+        assert _choose_description(None, _RENT_REAL_DESCRIPTION) == _RENT_REAL_DESCRIPTION
+        assert _choose_description("", _RENT_REAL_DESCRIPTION) == _RENT_REAL_DESCRIPTION
+
+    def test_info_preferred_over_please_note(self):
+        # Both populated and both have signal → info wins, mirroring the
+        # original `info or pleaseNote` precedence.
+        assert (
+            _choose_description(_RENT_REAL_DESCRIPTION, "different note")
+            == _RENT_REAL_DESCRIPTION
+        )
+
+    def test_info_boilerplate_falls_through_to_please_note(self):
+        # info is boilerplate but pleaseNote carries real signal — pick pleaseNote.
+        assert (
+            _choose_description(_SYLVEE_BOILERPLATE, _RENT_REAL_DESCRIPTION)
+            == _RENT_REAL_DESCRIPTION
+        )


### PR DESCRIPTION
## Summary

Addresses audit issues #177 (Rebirth Brass Band) and #178 (Highly Suspect): TM's Discovery API populates `info` / `pleaseNote` on most Madison events with templated per-venue policy boilerplate (cashless policy, bag-search rules, ADA seating, door times, GA seating) rather than event-specific copy. The scraper was passing that text through verbatim as `Event.description`.

- Added `_scrub_boilerplate()` (regex set derived from a 200-event live-feed survey) and `_choose_description()` to `backend/app/scrapers/ticketmaster.py`. When scrubbing leaves <40 chars of residue, the raw description is dropped to `None`; otherwise the original raw text is preserved so mixed boilerplate + real-event copy stays intact.
- The issue's suggested `attractions[].description` fallback is unusable — the survey confirmed it is empty across every event TM returns at the city search level.
- Rewrote the description-related tests with literal-string regressions for both audit events (info and pleaseNote variants), plus coverage for Orpheum tiered-GA boilerplate, Barrymore "theatre"/"theater" spellings, cancellation placeholder, mixed real content, and merge precedence.

## Verification

Performed against a freshly-built dev compose stack with a TM-only scrape (`?scraper=Ticketmaster&days=30&skip_geocode=true&skip_tag=true`) on a fresh Postgres volume.

- [x] `ruff check backend/` clean
- [x] Full backend test suite passes (254 / 254)
- [x] `/events?date=2026-05-17` — Highly Suspect now returns `description: null` (was 781 chars of Sylvee boilerplate). Fixes #178.
- [x] `/events?date=2026-05-15` — Rebirth Brass Band now returns `description: null` (was 733 chars of Majestic boilerplate). Fixes #177.
- [x] Real-content control — Capital City Theatre's RENT keeps its full 813-char description; events with VIP package copy (DILLSTRADAMUS, Good Kid, Comedy Bang! Bang!), charity partnership notes (Courtney Barnett / PLUS1), reschedule notices (Jacqueline Novak, Cheap Trick), and festival lineup notes (Mad With Power Fest) all retain their text.
- [x] Scrape stats: `inserted=51, updated=1, deactivated=0` from a single Ticketmaster pull.

No manual checks needed — every verification step ran against the local HTTP API + DB. The frontend already handles `description=null` (existing High Noon events have always had no description), so no frontend changes are required.

closes #178
closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)