### PR TITLE
Mark Eventbrite as rejected source (closes #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ whats-up-madison/
 
 - **Step 1 — Skeleton** ✅ Repo structure, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class
 - **Step 2 — First scraper + frontend** ✅ Multi-source data model (`Event`/`EventSource`), ingestion utility, React/Vite/Tailwind frontend with date picker and event cards
-- **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); Eventbrite API, City of Madison, and individual venue HTML scrapers still planned. Daily automation runs out-of-process for now (cron / systemd timer hitting `/admin/scrape`); no in-process scheduler.
+- **Step 3 — More scrapers** 🔄 Isthmus integrated (iCal + RSS, 30-day window) and Visit Madison integrated (Simpleview JSON API, 30-day window, with category pre-tagging from the source's own taxonomy); City of Madison and individual venue HTML scrapers still planned. Daily automation runs out-of-process for now (cron / systemd timer hitting `/admin/scrape`); no in-process scheduler.
 - **Step 4 — Categories** ✅ Closed taxonomy in `backend/app/categories.py` (15 tags); Visit Madison events pre-tagged from the source taxonomy; LLM-assisted tagging pass shipped in `backend/app/tagger.py` (runs at the end of `/admin/scrape` and via the standalone `/admin/tag` endpoint, with the system prompt cached); frontend filter UI shipped (multi-select tag cloud, sensible defaults, localStorage)
 - **Step 5 — Map view** ✅ Geocoding pipeline (Nominatim, cached per venue in `venue_geocodes` so re-scrapes are free) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve
 - **Recent polish** ✅ Fuzzy cross-source dedup in ingest (title similarity ≥ 0.65 anchored by time + venue); explicit source priority ranking; Isthmus description enrichment from event detail pages; Previous/Next nav buttons; sticky-header layout fixes
@@ -177,7 +177,7 @@ Returns active events for a given date. Long-running events appear on every date
     "status": "active",
     "sources": [
       {"source_name": "Isthmus", "source_url": "https://isthmus.com/events/..."},
-      {"source_name": "Eventbrite", "source_url": "https://..."}
+      {"source_name": "Ticketmaster", "source_url": "https://..."}
     ]
   }
 ]

--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -47,9 +47,9 @@ These cover many venues and event types from a single source. Highest leverage i
 
 ### Eventbrite
 - URL: https://www.eventbrite.com/d/wi--madison/events/
-- Scraper type prospect: api
-- Status: **investigating**
-- Notes: Has a public API (token required). Strong long-tail coverage of meetups, classes, nightlife, food. Verify current API access tier and rate limits.
+- Scraper type: api → none
+- Status: **rejected**
+- Reason: Eventbrite's public Event Search API (`GET /v3/events/search/`) was deprecated Dec 2019 and turned off Feb 20 2020. The remaining public endpoints require a known event/venue/organization ID; there is no supported "events in a city" query. HTML scraping of `/d/wi--madison/events/` is technically feasible (the listing page exposes ~112 JSON-LD `Event` entries on the first response) but is ToS-questionable and likely IP-fragile from Fly.io's range — same failure pattern that retired the Overture scraper (#162). Revisit only if either (a) Eventbrite reopens a public discovery API or (b) we gain a non-datacenter egress path (residential proxy, Cloudflare Worker fetch, etc.).
 
 ### Meetup
 - URL: https://www.meetup.com/find/us--wi--madison/


### PR DESCRIPTION
## Summary

Closes #69. Documents that an Eventbrite scraper is not feasible and updates supporting docs accordingly. No code changes.

The issue was framed around Eventbrite's "public API that requires an API token." Investigation found that premise falsified:

- Eventbrite's public Event Search API (`GET /v3/events/search/`) was deprecated in Dec 2019 and turned off Feb 20 2020. The remaining public endpoints (`/events/:id/`, `/venues/:id/events/`, `/organizations/:id/events/`) all require IDs the caller already owns or knows — there is no supported "events in a city" query in 2026.
- HTML scraping `https://www.eventbrite.com/d/wi--madison/events/` is technically feasible (~112 JSON-LD `Event` blocks per page) but ToS-questionable and likely IP-fragile from Fly.io's range — same failure pattern that retired the Overture scraper in #162.
- A per-organization API ingestion (still-supported endpoint) would need a hand-curated organizer list with poor coverage and high maintenance cost.

So this PR memorializes the dead-end so future maintainers and AI agents don't re-investigate from scratch.

## Changes

- `docs/EVENT_SOURCES.md`: Eventbrite section moves from `investigating` to `rejected` with a full Reason block — deprecation history, why HTML scraping wasn't pursued, and revival conditions. Shape mirrors the existing rejected/deferred entries (Overture, today.wisc.edu).
- `README.md`: removes the stale "Eventbrite API … still planned" mention from the Step 3 roadmap line; updates the multi-source JSON example for a Sylvee event to cite Ticketmaster (which actually covers The Sylvee per the integrated scrapers) rather than Eventbrite.

## Verification

- [x] `git diff` shows exactly 2 files / 5 insertions / 5 deletions, matching the plan
- [x] `grep -rni "eventbrite"` returns only the new `rejected` entry — no other stale refs in `docs/`, `backend/`, `frontend/`, or `README.md`
- [x] `ruff check backend/` passes (no Python changed)
- [x] No `backend/app/scrapers/eventbrite.py` ever existed, so no code to remove
- [x] Skim the updated Eventbrite section in `docs/EVENT_SOURCES.md` in GitHub's markdown render — confirm the prose reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)