### PR TITLE
Mark Bandsintown as rejected source (closes #76)

### DIFF
--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -89,9 +89,9 @@ These cover many venues and event types from a single source. Highest leverage i
 
 ### Bandsintown
 - URL: https://www.bandsintown.com/c/madison-wi
-- Scraper type prospect: api
-- Status: **investigating**
-- Notes: Concert aggregator with a public API. Good fallback for music coverage if direct venue scrapers miss anything.
+- Scraper type: api → none
+- Status: **rejected**
+- Reason: Investigated for #76 in May 2026 and ruled out on three independent grounds. (1) The public REST API at `rest.bandsintown.com` is **artist-centric only** — the documented event endpoint is `GET /v3.1/artists/{name}/events?app_id=...`, with no city/location discovery route. Probing `/v3.1/cities/madison-wi/events`, `/v4/...`, and the retired `api.bandsintown.com/v2/events.json?location=...` all return `MissingAuthenticationTokenException` (route does not exist on the public API gateway). City-wide aggregation would require us to maintain a manual artist allowlist, which defeats the point of a fallback aggregator. (2) `www.bandsintown.com/c/madison-wi` is fronted by **Cloudflare** and returns the "Sorry, you have been blocked" interstitial (HTTP 403, `cf-ray` set) from a non-datacenter residential IP — Fly.io's range will be blocked at least as aggressively (same failure pattern that retired Overture in #162 and Eventbrite in #182), so HTML scraping isn't a viable path either. (3) Bandsintown's location-aware **Partner API** exists but is B2B/approval-gated, pitched at venue/promoter partners rather than third-party aggregators, and would impose a different ToS than the public API. Coverage gap is acceptable: Madison's ticketed concert volume is already covered by the **Ticketmaster** (Sylvee, Majestic, Orpheum, Barrymore, Overture, Kohl Center), **High Noon Saloon**, and **Atwood Music Hall** scrapers, with DIY/independent shows surfaced via **Isthmus**. Revisit only if (a) Bandsintown reopens a public city-search API or (b) we gain a non-datacenter egress path (residential proxy, Cloudflare Worker fetch) *and* find a documented HTML or feed surface that carries city-keyed event data.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #76. Documents in `docs/EVENT_SOURCES.md` that the Bandsintown aggregator is not viable as a What's Up Madison data source, mirroring the rejection/deferral pattern used for Eventbrite (#182) and Overture (#162).

## Investigation findings

Probed from a non-datacenter residential IP in May 2026:

- **Public REST API is artist-centric only.** `rest.bandsintown.com` exposes `GET /v3.1/artists/{name}/events?app_id=...` and nothing location-based. `/v3.1/cities/madison-wi/events`, `/v4/...`, and the retired `api.bandsintown.com/v2/events.json?location=...` all return `MissingAuthenticationTokenException` (route doesn't exist on the public API gateway). A city-wide aggregator would have to maintain a manual artist allowlist, defeating the point of a fallback.
- **Web frontend is Cloudflare-blocked.** `https://www.bandsintown.com/c/madison-wi` returns the "Sorry, you have been blocked" interstitial (HTTP 403, `server: cloudflare`, `cf-ray` set) even from a residential IP — Fly.io's datacenter range will be blocked at least as aggressively. Same failure pattern as Overture and Eventbrite.
- **Partner API is B2B-only.** Approval-gated, pitched at venue/promoter partners, would land us under a different ToS than the public API.

Coverage gap is acceptable: Ticketmaster (Sylvee, Majestic, Orpheum, Barrymore, Overture, Kohl Center), High Noon Saloon, Atwood Music Hall, and Isthmus already cover Madison's concert volume.

## Verification

- [x] Single-file doc change: only `docs/EVENT_SOURCES.md` Bandsintown entry updated (Status → **rejected**, scraper type annotated `api → none`, Reason block added with revisit conditions)
- [x] `~/miniconda3/envs/whats-up-madison/bin/ruff check backend/` — clean (no code changes; sanity-check pass)
- [x] `grep -n "Bandsintown" docs/EVENT_SOURCES.md` — confirmed single occurrence, no other references needed updating
- [ ] Skim updated entry to confirm tone and revisit conditions match preference