### PR TITLE
Mark Meetup as rejected source (closes #70)

### DIFF
--- a/docs/EVENT_SOURCES.md
+++ b/docs/EVENT_SOURCES.md
@@ -53,9 +53,9 @@ These cover many venues and event types from a single source. Highest leverage i
 
 ### Meetup
 - URL: https://www.meetup.com/find/us--wi--madison/
-- Scraper type prospect: api (uncertain)
-- Status: **investigating**
-- Notes: Best source for recurring social/professional/hobby groups. Public API access has been restricted in recent years; confirm whether GraphQL API is usable for our case.
+- Scraper type: api → none
+- Status: **rejected**
+- Reason: Investigated for #70 in May 2026 and ruled out on machine-policy grounds. (1) Meetup's `robots.txt` explicitly disallows the GraphQL API at `https://www.meetup.com/gql*` for all user-agents — that's the only programmatic event surface, and the issue body's "GraphQL API" path is named directly in the disallow list. The legacy gateway at `api.meetup.com/gql` returns HTTP 404 (decommissioned). (2) `robots.txt` also disallows every URL parameter we'd need to filter events from the HTML surface: `?location=*`, `?categoryId=*`, `?dateRange=*`, `?eventType=*`, `?distance=*`, `?radius=*`, `?keywords=*`, plus `/n/*`, `/mu_api/`, and `/api/?`. `GPTBot` is fully disallowed in a separate stanza — broader stance against automated crawling. (3) The unparameterized city find page `/find/us--wi--madison/` itself is robots-allowed and returns 45 JSON-LD `Event` blocks with name/startDate/endDate/location.address/url, but is too thin to be useful as a scraper: no pagination (no `rel="next"`, no `?page=` anchors), no date or category control (those params are all disallowed), `description` is empty in JSON-LD so we'd need a second per-event fetch on a host that doesn't want bots. A sample run covered 2026-05-14 → 2026-06-06 — the "soonest 45" default sort with no way to widen the window. (4) Meetup's GraphQL docs (`meetup.com/api` → `/graphql/`) frame the API around "Business Solutions" for Meetup Pro customers, indicating it's gated behind the paid org subscription, not a per-app free developer key. Coverage gap is acceptable: **Isthmus** already surfaces many of Madison's recurring community/hobby events (Toastmasters, civic meetings, hobby clubs, social gatherings), and the LLM tagger handles `Community & Clubs` / `Health & Wellness` / `Talks & Learning` tagging for events from other sources. Revisit only if (a) Meetup reopens an unauthenticated city-search API, or (b) `robots.txt` relaxes `/gql*` and the event-filter params, or (c) we acquire a Meetup Pro / Partner credential whose ToS permits aggregation.
 
 ### City of Madison
 - URL: https://www.cityofmadison.com/events


### PR DESCRIPTION
## Summary

Closes #70. Documents that a Meetup scraper is not feasible and updates the source catalog accordingly. No code changes.

The issue framed Meetup as the "best source for recurring social/professional/hobby groups" with a GraphQL API of uncertain accessibility. Investigation falsified the premise:

- **`robots.txt` explicitly disallows `/gql*`** for all user-agents — the GraphQL API named in the issue body is forbidden by Meetup's own machine-readable policy. The legacy gateway at `api.meetup.com/gql` is decommissioned (HTTP 404).
- **Every event-filter URL param is disallowed** in `robots.txt`: `?location=*`, `?categoryId=*`, `?dateRange=*`, `?eventType=*`, `?distance=*`, `?radius=*`, `?keywords=*`, plus `/n/*`, `/mu_api/`, `/api/?`. `GPTBot` is fully disallowed in a separate stanza.
- **The robots-allowed surface is too thin.** The unparameterized `/find/us--wi--madison/` page is 200 OK with 45 JSON-LD `Event` blocks (name, startDate, endDate, full address, url) — but has no pagination, no date/category control, and empty descriptions. Sample run covered 2026-05-14 → 2026-06-06, the default "soonest 45" with no way to widen the window.
- **GraphQL API positioned as paid.** Meetup's API docs (`meetup.com/api` → `/graphql/`) frame access around "Business Solutions" for Meetup Pro customers — gated behind the paid org subscription, not a per-app free developer key.

Coverage gap is acceptable: **Isthmus** already surfaces many recurring Madison community/hobby events (Toastmasters, civic meetings, hobby clubs), and the LLM tagger handles `Community & Clubs` / `Health & Wellness` / `Talks & Learning` tagging for events from other sources.

Mirrors the rejection pattern of #182 (Eventbrite) and #183 (Bandsintown).

## Changes

- `docs/EVENT_SOURCES.md`: Meetup section moves from `investigating` to `rejected` with a full Reason block covering the four findings above and the three revisit conditions (Meetup reopens unauthenticated city search; `robots.txt` relaxes `/gql*` and event-filter params; we acquire a Meetup Pro / Partner credential whose ToS permits aggregation).
- Shape mirrors existing `rejected` entries (Eventbrite, Bandsintown).

## Verification

- [x] `git diff --stat` shows only `docs/EVENT_SOURCES.md` changed (3 ins / 3 del)
- [x] `grep -rn -i meetup docs/ README.md frontend/src backend/app` returns only the new entry — other hits are the unrelated common-noun "meetups" (e.g. "social meetups" in `categories.py`)
- [x] `ls backend/app/scrapers/ | grep meetup` exits 1 — no scraper code ever existed, nothing to remove
- [x] `~/miniconda3/envs/whats-up-madison/bin/ruff check backend/` passes (sanity, no Python touched)
- [ ] Skim the updated Meetup section in `docs/EVENT_SOURCES.md` in GitHub's markdown render to confirm the prose reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)