### PR TITLE
Fix mobile sub-pixel line between density rail and first bucket header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -190,9 +190,11 @@ export default function App() {
   // sub-pixel mismatch between the measured height and the actually-rendered
   // bottom edge of the element above is hidden by the higher-z element. The
   // header's z-30 covers the rail's z-20; the rail's gradient covers the
-  // bucket headers' z-10.
+  // bucket headers' z-10. Each step subtracts one more pixel than the last so
+  // the overlap compounds — rail starts at (headerH − 1), bucket starts at
+  // (rail's bottom − 1) = (headerH − 1 + railH) − 1 = headerH + railH − 2.
   const railTop = Math.max(0, headerH - 1)
-  const bucketTop = Math.max(0, headerH + railH - 1)
+  const bucketTop = Math.max(0, headerH + railH - 2)
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Density rail (z-20) overlapped header (z-30) by 1px, but the first bucket section (z-10) was positioned exactly at the rail's bottom edge with **zero overlap** — on mobile screens with non-integer DPR, sub-pixel rounding leaves a fractional gap there, showing the page background gradient as a visible thin line between the rail and the "Evening" / first-bucket header.
- Fix: subtract one more pixel from `bucketTop` so the bucket actually overlaps the rail by 1px, mirroring the header/rail relationship. Rail's z-20 covers the bucket's z-10 top edge, hiding sub-pixel mismatch.
- Touched only `frontend/src/App.jsx` (one-line math change in the sticky-offset block plus a tightened comment explaining the compounding arithmetic).

## Verification
- [x] `npm run lint` passes (eslint, matches CI's `frontend-lint` job)
- [x] `npm run build` succeeds (Vite production build)
- [x] `ruff check backend/` passes (matches CI's `lint` job; no backend changes but cheap sanity check)
- [x] Diff is exactly the intended one-line offset change + comment update
- [ ] On mobile (the device from the issue screenshot), scroll the list view until the density rail and the first bucket header are both stuck to the top, and confirm the thin pale-blue line between them is gone
- [ ] On desktop, confirm the bucket header didn't visually shift — its top 1px is hidden behind the rail's gradient bottom, which is the intended behavior

closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)