### PR TITLE
Decode HTML entities in Our Lives titles (closes #192)

### DIFF
--- a/backend/app/scrapers/dmi.py
+++ b/backend/app/scrapers/dmi.py
@@ -134,9 +134,10 @@ def _parse_event(doc: dict) -> RawEvent | None:
     if not _in_madison_metro(venue):
         return None
 
-    # The DMI API ships HTML entities raw in titles (e.g. `What&#8217;s Up
-    # Downtown`), unlike Our Lives' API which decodes them server-side. Unescape
-    # here so the canonical_hash and rendered card text are both clean.
+    # The DMI Tribe Events API ships HTML entities raw in titles (e.g.
+    # `What&#8217;s Up Downtown`). Unescape here so the canonical_hash and
+    # rendered card text are both clean. (Our Lives' Tribe API has the same
+    # behavior — see its scraper.)
     title = html.unescape((doc.get("title") or "").strip())
     source_url = (doc.get("url") or "").strip()
     if not title or not source_url:

--- a/backend/app/scrapers/our_lives.py
+++ b/backend/app/scrapers/our_lives.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import re
 import time
@@ -169,7 +170,12 @@ def _parse_event(doc: dict) -> RawEvent | None:
     if not _in_madison_metro(venue):
         return None
 
-    title = (doc.get("title") or "").strip()
+    # The Our Lives Tribe Events REST API ships HTML entities raw in titles
+    # (e.g. `Dayshift &#8211; The 30+ Daytime Party`). Decode them so the
+    # canonical_hash, fuzzy-dedup title similarity, and rendered card text all
+    # see the human-readable form. Without this, the same event scraped via
+    # another source (Atwood Music Hall) doesn't dedup against ours (#192).
+    title = html.unescape((doc.get("title") or "").strip())
     source_url = (doc.get("url") or "").strip()
     if not title or not source_url:
         return None
@@ -197,7 +203,9 @@ def _parse_event(doc: dict) -> RawEvent | None:
 
     description = clean_html_text(doc.get("description") or "") or None
 
-    venue_name = (venue.get("venue") or "").strip() or None
+    # Same entity-decoding as the title — venue_name participates in the
+    # canonical_hash and is rendered on the card.
+    venue_name = html.unescape((venue.get("venue") or "").strip()) or None
     venue_address = _build_address(venue)
 
     return RawEvent(

--- a/backend/tests/test_dmi.py
+++ b/backend/tests/test_dmi.py
@@ -102,7 +102,7 @@ def _base_doc(**overrides) -> dict:
     """Minimal shape matching a real DMI Tribe Events API response.
 
     HTML-entity-encoded title preserved verbatim from the live API response —
-    DMI does NOT decode entities server-side (unlike Our Lives).
+    the DMI Tribe Events feed does not decode entities server-side.
     """
     doc = {
         "title": "What&#8217;s Up Downtown",
@@ -144,7 +144,7 @@ class TestParseEvent:
         assert ev.source_url == "https://downtownmadison.org/event/whats-up-downtown-2026-05-28/"
 
     def test_html_entity_title_decoded(self):
-        # The defining behavioral difference from Our Lives' parser.
+        # Both Tribe-backed scrapers (DMI and Our Lives) decode title entities.
         ev = _parse_event(_base_doc(title="2026 DMI Annual Celebration &amp; Awards"))
         assert ev is not None
         assert ev.title == "2026 DMI Annual Celebration & Awards"

--- a/backend/tests/test_our_lives.py
+++ b/backend/tests/test_our_lives.py
@@ -272,12 +272,27 @@ class TestParseEvent:
     def test_invalid_start_date_returns_none(self):
         assert _parse_event(_base_doc(start_date="not a date")) is None
 
-    def test_html_entities_in_title_preserved(self):
-        # Title arrives as the API-decoded value; we don't double-decode.
-        # Description is the only HTML we clean.
-        ev = _parse_event(_base_doc(title="National Women's Music Festival"))
+    def test_html_entity_title_decoded(self):
+        # Real-world: the live Tribe API ships en-dashes as `&#8211;` in titles
+        # (e.g. "Dayshift &#8211; The 30+ Daytime Party"). The undecoded form
+        # broke canonical_hash dedup against Atwood's plain-hyphen variant of
+        # the same event (#192).
+        ev = _parse_event(_base_doc(title="Dayshift &#8211; The 30+ Daytime Party"))
         assert ev is not None
-        assert ev.title == "National Women's Music Festival"
+        assert ev.title == "Dayshift – The 30+ Daytime Party"
+
+    def test_html_entity_venue_name_decoded(self):
+        # venue_name participates in the canonical_hash too, so the same
+        # decoding must happen there.
+        ev = _parse_event(_base_doc(venue={
+            "venue": "Smith &amp; Sons",
+            "address": "1 Main St",
+            "city": "Madison",
+            "state": "WI",
+            "zip": "53703",
+        }))
+        assert ev is not None
+        assert ev.venue_name == "Smith & Sons"
 
     def test_unusual_timezone_falls_back_to_central(self):
         ev = _parse_event(_base_doc(timezone="Not/A_Zone"))


### PR DESCRIPTION
## Summary

Fixes issue #192 — the same event was appearing twice in production: Atwood Music Hall's `Dayshift - The 30+ Daytime Party` and Our Lives's `Dayshift &#8211; The 30+ Daytime Party`.

Empirical check (`curl` against `https://ourliveswisconsin.com/wp-json/tribe/events/v1/events`) confirmed the Our Lives Tribe REST API ships HTML entities raw in titles. The scraper stored them verbatim, so the entity-encoded title participated in `canonical_hash` and the fuzzy-dedup title similarity check — both diverged from sibling scrapers' decoded versions of the same event.

The DMI scraper already does this exact decode (`backend/app/scrapers/dmi.py:140`); its inline comment claiming Our Lives decodes server-side is incorrect and is fixed in this PR.

## Changes

- `backend/app/scrapers/our_lives.py` — `html.unescape()` on `title` and `venue_name` in `_parse_event`.
- `backend/app/scrapers/dmi.py` — corrects the outdated "(unlike Our Lives)" comment.
- `backend/tests/test_our_lives.py` — replaces a stale test that codified the now-fixed bug with two real regression tests: `test_html_entity_title_decoded` (en-dash) and `test_html_entity_venue_name_decoded` (`&amp;`).
- `backend/tests/test_dmi.py` — drops the same false "(unlike Our Lives)" qualifier from two comments.

After the fix, Our Lives's title decodes to `Dayshift – The 30+ Daytime Party` (en-dash). It still won't exact-hash against Atwood's plain hyphen, but `ingest._fuzzy_find_event` (`SequenceMatcher` ≥ 0.65, anchored by `start_at` + `venue_name`) merges them on the next scrape.

## Verification

- [x] `ruff check backend/` passes
- [x] `pytest backend/tests/` — 319 tests pass (was 317; 2 new regression tests added)
- [x] Regression tests fail without the scraper fix and pass with it (entity-decoded titles confirmed)
- [ ] After deploy + next scrape, `https://whats-up-madison.fly.dev/events/search?q=dayshift` returns a single merged event with both `Atwood Music Hall` and `Our Lives` in its `sources` array (production cron-scheduled; not blocking for merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)