### PR TITLE
Fix #191: normalize "&" vs "and" in ingest fuzzy-dedup title comparison

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -191,6 +191,19 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
     return stats
 
 
+def _normalize_title_for_match(title: str) -> str:
+    """Lowercase + strip + collapse ' & ' to ' and ' so the fuzzy substring
+    check (and SequenceMatcher ratio) treats the two as the same token.
+
+    Targets the literal pattern (with surrounding spaces) so compound tokens
+    like "L&G" aren't mangled. Added for #191, where Visit Madison shipped
+    two listings for the same Karben4 trivia night as "Brews & Q's Taproom
+    Trivia at Karben4" and "Brews and Q's" — the shorter title is only a
+    substring of the longer after this normalization.
+    """
+    return title.lower().strip().replace(" & ", " and ")
+
+
 def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
     """Return an existing Event that is likely the same real-world event as raw.
 
@@ -216,11 +229,11 @@ def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":
     if not candidates:
         return None
 
-    raw_title = raw.title.lower().strip()
+    raw_title = _normalize_title_for_match(raw.title)
     best: "Event | None" = None
     best_ratio = 0.0
     for event in candidates:
-        cand_title = event.title.lower().strip()
+        cand_title = _normalize_title_for_match(event.title)
         ratio = SequenceMatcher(None, raw_title, cand_title).ratio()
         # When one title is fully contained in the other (e.g. "Pert Near
         # Sandstone" vs "Pert Near Sandstone-Side by Side Album Release …"),

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -171,6 +171,51 @@ def test_unrelated_titles_do_not_merge_via_substring(db):
     assert db.query(Event).count() == 2
 
 
+def test_ampersand_and_normalize_merges_substring(db):
+    # Issue #191: Visit Madison shipped two listings for the same Karben4 trivia
+    # night, "Brews & Q's Taproom Trivia at Karben4" and "Brews and Q's". The
+    # fuzzy substring branch missed because the shorter title isn't literally
+    # contained in the longer until " & " is normalized to " and ".
+    long_title = "Brews & Q's Taproom Trivia at Karben4"
+    short_title = "Brews and Q's"
+
+    ingest_events(
+        "Source A",
+        [_raw(title=long_title, venue_name="Karben4 Brewing")],
+        db,
+    )
+    ingest_events(
+        "Source A",
+        [_raw(
+            title=short_title,
+            venue_name="Karben4 Brewing",
+            source_url="https://a.example/2",
+        )],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    # Reverse direction: short first, long second — also merges.
+    db.query(EventSource).delete()
+    db.query(Event).delete()
+    db.commit()
+    ingest_events(
+        "Source A",
+        [_raw(title=short_title, venue_name="Karben4 Brewing")],
+        db,
+    )
+    ingest_events(
+        "Source A",
+        [_raw(
+            title=long_title,
+            venue_name="Karben4 Brewing",
+            source_url="https://a.example/3",
+        )],
+        db,
+    )
+    assert db.query(Event).count() == 1
+
+
 # ---------------------------------------------------------------------------
 # 5. Staleness: event removed from a run → EventSource inactive, Event removed
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #191. The fuzzy-dedup substring branch in `_fuzzy_find_event` (`backend/app/ingest.py`) compared lowered/stripped titles verbatim, so "Brews & Q's Taproom Trivia at Karben4" never contained "Brews and Q's" — and the `SequenceMatcher` ratio (0.40) was well below the 0.65 threshold. Two Visit Madison listings for the same Karben4 trivia night ended up as two `Event` rows.

This change adds a small `_normalize_title_for_match` helper that lowercases, strips, and replaces `" & "` with `" and "`, used for both sides of the fuzzy comparison. The substring branch then matches, ratio is forced to 1.0, and the rows merge.

`canonical_hash` is intentionally left alone — adding the same normalization there would invalidate every event hash currently in the DB without incremental benefit, since the fuzzy path already catches the case after this change.

Out of scope: the third Karben4 trivia row in the screenshot (Isthmus, 7:30 PM) has a different `start_at` than the two Visit Madison rows (6:30 PM); the fuzzy matcher requires an exact `start_at` anchor for timed events, so it would not merge regardless of title normalization. Separate issue if we want to widen the time tolerance.

## Verification
- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/` — 320 passed (includes new regression test `test_ampersand_and_normalize_merges_substring`)
- [x] Confirmed pre-fix behavior fails the merge: `SequenceMatcher.ratio("brews & q's taproom trivia at karben4", "brews and q's") = 0.40`, substring `False`
- [x] Confirmed post-fix behavior merges: after `" & " → " and "`, substring `True`, ratio forced to 1.0
- [ ] After merge + next Visit Madison scrape: confirm the two prod rows referenced in #191 either merge (if Visit Madison re-orders the listings such that both raws fall through to fuzzy match against an empty bucket) or wait for staleness deactivation to retire one. The fix is forward-looking; prod cleanup may take one scrape cycle or one listing dropping off the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)