### PR TITLE
Fix #187: strip trailing " - Madison" suffix in ingest dedup key

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -200,8 +200,22 @@ def _normalize_title_for_match(title: str) -> str:
     two listings for the same Karben4 trivia night as "Brews & Q's Taproom
     Trivia at Karben4" and "Brews and Q's" — the shorter title is only a
     substring of the longer after this normalization.
+
+    Also strips a trailing city suffix (" - madison", " - madison, wi") that
+    Visit Madison appends to disambiguate touring acts (#187: their listing
+    titled the show "Anberlin - Madison" while Atwood listed it as "Anberlin
+    with Emery, Watashi Wa & Motion Light" — without this strip, neither
+    title is a substring of the other and the SequenceMatcher ratio falls
+    below the fuzzy threshold). Anchored to the end so titles that mention
+    Madison mid-string (e.g. "Concert - Madison Symphony") are untouched.
+    Applied only to the matching key — stored titles are unchanged.
     """
-    return title.lower().strip().replace(" & ", " and ")
+    s = title.lower().strip().replace(" & ", " and ")
+    for suffix in (" - madison, wi", " - madison"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)].rstrip()
+            break
+    return s
 
 
 def _fuzzy_find_event(raw: RawEvent, db: Session) -> "Event | None":

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -171,6 +171,57 @@ def test_unrelated_titles_do_not_merge_via_substring(db):
     assert db.query(Event).count() == 2
 
 
+def test_madison_city_suffix_normalize_merges(db):
+    # Issue #187: Visit Madison appended " - Madison" to disambiguate a
+    # touring act ("Anberlin - Madison"), while Atwood Music Hall used the
+    # full bill ("Anberlin with Emery, Watashi Wa & Motion Light"). Neither
+    # title is a substring of the other and SequenceMatcher.ratio is ~0.42,
+    # well below the 0.65 threshold, so the two rows were ingested as
+    # separate events despite identical start_at + venue_name. Stripping the
+    # trailing city suffix from the matching key makes the shorter title a
+    # substring of the longer.
+    visit_madison_title = "Anberlin - Madison"
+    atwood_title = "Anberlin with Emery, Watashi Wa & Motion Light"
+
+    ingest_events(
+        "Visit Madison",
+        [_raw(title=visit_madison_title, venue_name="Atwood Music Hall")],
+        db,
+    )
+    ingest_events(
+        "Atwood Music Hall",
+        [_raw(
+            title=atwood_title,
+            venue_name="Atwood Music Hall",
+            source_url="https://www.theatwoodmusichall.com/shows/2026-5-20",
+        )],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+    # Reverse direction: venue scraper first, Visit Madison second — also merges.
+    db.query(EventSource).delete()
+    db.query(Event).delete()
+    db.commit()
+    ingest_events(
+        "Atwood Music Hall",
+        [_raw(title=atwood_title, venue_name="Atwood Music Hall")],
+        db,
+    )
+    ingest_events(
+        "Visit Madison",
+        [_raw(
+            title=visit_madison_title,
+            venue_name="Atwood Music Hall",
+            source_url="https://www.visitmadison.com/event/anberlin-madison/76278/",
+        )],
+        db,
+    )
+    assert db.query(Event).count() == 1
+
+
 def test_ampersand_and_normalize_merges_substring(db):
     # Issue #191: Visit Madison shipped two listings for the same Karben4 trivia
     # night, "Brews & Q's Taproom Trivia at Karben4" and "Brews and Q's". The


### PR DESCRIPTION
## Summary

- Visit Madison's listing for the May 20, 2026 Atwood show titled the event `Anberlin - Madison`; Atwood Music Hall titled it `Anberlin with Emery, Watashi Wa & Motion Light`. Identical `start_at` + canonical `venue_name`, but `SequenceMatcher.ratio` was ~0.42 and neither title was a substring of the other, so ingest fuzzy-dedup missed and stored two rows.
- Strip a trailing ` - madison` / ` - madison, wi` from the matching key in `_normalize_title_for_match` (`backend/app/ingest.py`). Anchored to the end, applied only to the dedup key, so stored titles are unchanged and mid-string mentions like "Concert - Madison Symphony" stay intact.
- Adds a regression test covering both ingest orderings (Visit Madison first / Atwood first).

closes #187

## Verification

- [x] `ruff check backend/` passes
- [x] `pytest backend/tests/` passes (321 tests, including the new `test_madison_city_suffix_normalize_merges` and the existing `test_unrelated_titles_do_not_merge_via_substring` over-merge guard)
- [x] Spot-checked normalization in REPL:
  - `_normalize_title_for_match("Anberlin - Madison")` → `"anberlin"`
  - `_normalize_title_for_match("Anberlin - Madison, WI")` → `"anberlin"`
  - `_normalize_title_for_match("Concert - Madison Symphony")` → unchanged
  - `_normalize_title_for_match("Brews & Q's")` → `"brews and q's"` (existing behavior preserved)
- [ ] After merge + auto-deploy, confirm the next `/admin/scrape` collapses the two Anberlin rows. The Atwood row (higher trust) will overwrite the merged event's title/description per `_OVERWRITABLE_FIELDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)