### PR TITLE
Fix Ticketmaster event links returning 404

### DIFF
--- a/backend/app/scrapers/ticketmaster.py
+++ b/backend/app/scrapers/ticketmaster.py
@@ -121,23 +121,6 @@ def _choose_description(info: str | None, please_note: str | None) -> str | None
             return raw
     return None
 
-# US state code → full lowercase name for canonical URL slug construction.
-_STATE_NAMES: dict[str, str] = {
-    "AL": "alabama", "AK": "alaska", "AZ": "arizona", "AR": "arkansas",
-    "CA": "california", "CO": "colorado", "CT": "connecticut", "DE": "delaware",
-    "FL": "florida", "GA": "georgia", "HI": "hawaii", "ID": "idaho",
-    "IL": "illinois", "IN": "indiana", "IA": "iowa", "KS": "kansas",
-    "KY": "kentucky", "LA": "louisiana", "ME": "maine", "MD": "maryland",
-    "MA": "massachusetts", "MI": "michigan", "MN": "minnesota", "MS": "mississippi",
-    "MO": "missouri", "MT": "montana", "NE": "nebraska", "NV": "nevada",
-    "NH": "new-hampshire", "NJ": "new-jersey", "NM": "new-mexico", "NY": "new-york",
-    "NC": "north-carolina", "ND": "north-dakota", "OH": "ohio", "OK": "oklahoma",
-    "OR": "oregon", "PA": "pennsylvania", "RI": "rhode-island", "SC": "south-carolina",
-    "SD": "south-dakota", "TN": "tennessee", "TX": "texas", "UT": "utah",
-    "VT": "vermont", "VA": "virginia", "WA": "washington", "WV": "west-virginia",
-    "WI": "wisconsin", "WY": "wyoming", "DC": "district-of-columbia",
-}
-
 # Conservative segment/genre → our taxonomy mapping. Lookup order is
 # (segment, genre) first, then (segment, None). Anything unmapped is dropped
 # so the LLM tagging pass can enrich from description.
@@ -274,33 +257,6 @@ def _map_categories(classifications: list[dict]) -> list[str]:
     return [mapped] if mapped else []
 
 
-def _event_slug(s: str) -> str:
-    s = s.lower()
-    s = re.sub(r"[^a-z0-9\s]", "", s)
-    return re.sub(r"\s+", "-", s.strip())
-
-
-def _build_canonical_url(title: str, event_date: date, venue: dict, event_id: str) -> str | None:
-    """Construct a Ticketmaster canonical event URL from event metadata.
-
-    The Discovery API returns short /event/<id> URLs that fail for some users
-    due to Imperva bot-detection. The full slug URL
-    (/name-city-state-MM-DD-YYYY/event/<id>) is what TM shows in browser
-    address bars and is more reliably resolvable."""
-    if not event_id:
-        return None
-    city = ((venue.get("city") or {}).get("name") or "").strip()
-    state_code = ((venue.get("state") or {}).get("stateCode") or "").strip()
-    if not city or not state_code:
-        return None
-    state_name = _STATE_NAMES.get(state_code, state_code.lower())
-    slug = (
-        f"{_event_slug(title)}-{_event_slug(city)}-{state_name}"
-        f"-{event_date.strftime('%m-%d-%Y')}"
-    )
-    return f"https://www.ticketmaster.com/{slug}/event/{event_id}"
-
-
 def _parse_event(doc: dict) -> RawEvent | None:
     dates = doc.get("dates") or {}
     status = ((dates.get("status") or {}).get("code") or "").strip().lower()
@@ -350,11 +306,11 @@ def _parse_event(doc: dict) -> RawEvent | None:
     image_url = _select_image(doc.get("images") or [])
     categories = _map_categories(doc.get("classifications") or [])
 
-    event_id = (doc.get("id") or "").strip()
-    source_url = (
-        _build_canonical_url(title, event_date, venue, event_id)
-        or (doc.get("url") or "").strip()
-    )
+    source_url = (doc.get("url") or "").strip()
+    if not source_url:
+        event_id = (doc.get("id") or "").strip()
+        if event_id:
+            source_url = f"https://www.ticketmaster.com/event/{event_id}"
     if not source_url:
         return None
 

--- a/backend/tests/test_ticketmaster.py
+++ b/backend/tests/test_ticketmaster.py
@@ -350,6 +350,26 @@ class TestParseEvent:
     def test_missing_url_returns_none(self):
         assert _parse_event(_doc(url="")) is None
 
+    def test_api_url_used_directly_when_event_id_present(self):
+        # Regression for #206: slug URLs constructed from metadata 404 because
+        # TM's internal slug generation can't be replicated exactly. Use the
+        # URL the Discovery API returns for the event instead.
+        api_url = "https://www.ticketmaster.com/foo-madison-wi-01-01-2026/event/ABC123"
+        doc = _doc(url=api_url)
+        doc["id"] = "ABC123"
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert ev.source_url == api_url
+
+    def test_fallback_to_short_event_url_when_api_url_missing(self):
+        # When the url field is absent but id is present, fall back to the
+        # bare /event/<id> URL rather than dropping the event entirely.
+        doc = _doc(url="")
+        doc["id"] = "ABC123"
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert ev.source_url == "https://www.ticketmaster.com/event/ABC123"
+
     def test_missing_venue_returns_none(self):
         doc = _doc()
         doc["_embedded"] = {"venues": []}


### PR DESCRIPTION
## Summary

- Ticketmaster event links were returning 404 for all users (#206)
- Root cause: `_build_canonical_url` constructed slug URLs from event metadata (e.g. `modest-mouse-madison-wisconsin-09-29-2026/event/{id}`), but TM's internal slug generation can't be reliably replicated — differences in slug format (venue name inclusion, date format, `-tickets` suffix, etc.) produce URLs that don't resolve
- Fix: use the URL the Discovery API returns in the `url` field directly — TM already provides the correct canonical URL there. Falls back to `https://www.ticketmaster.com/event/{id}` if `url` is absent

Removes `_build_canonical_url`, `_event_slug`, and `_STATE_NAMES` from `ticketmaster.py`.

closes #206

## Verification

- [x] Lint (`ruff check backend/`) passes
- [x] Full test suite (375 tests) passes
- [x] New regression test `test_api_url_used_directly_when_event_id_present` asserts the API-provided URL is used verbatim
- [x] New regression test `test_fallback_to_short_event_url_when_api_url_missing` asserts the bare `/event/{id}` fallback works when the `url` field is absent
- [x] Existing `test_missing_url_returns_none` still exercises the "no URL at all → drop event" path