### PR TITLE
Fix City of Madison venue_address missing city/state/zip

### DIFF
--- a/backend/app/scrapers/city_of_madison.py
+++ b/backend/app/scrapers/city_of_madison.py
@@ -57,12 +57,14 @@ class CityOfMadisonSource(BaseSource):
         ok = fail = 0
         for ev in raw_events:
             time.sleep(_DETAIL_SLEEP)
-            desc = _fetch_detail_description(ev.source_url)
+            desc, full_addr = _fetch_detail(ev.source_url)
             if desc:
                 ev.description = desc
                 ok += 1
             else:
                 fail += 1
+            if full_addr:
+                ev.venue_address = full_addr
 
         logger.info(
             "City of Madison: %d events, detail enrichment %d/%d succeeded",
@@ -170,9 +172,7 @@ def _parse_item(content: Tag) -> RawEvent | None:
             venue_name = name_el.get_text(strip=True) or None
         street_el = addr_el.select_one("span")
         if street_el:
-            street = street_el.get_text(strip=True)
-            if street:
-                venue_address = street
+            venue_address = _parse_address_from_span(street_el)
 
     return RawEvent(
         title=title,
@@ -189,16 +189,32 @@ def _parse_item(content: Tag) -> RawEvent | None:
     )
 
 
-def _fetch_detail_description(url: str) -> str | None:
-    """Pull the event description from the detail page."""
+def _parse_address_from_span(span_el: Tag) -> str | None:
+    """Join all text lines from an address <span>, handling <br> separators."""
+    parts = [t.strip() for t in span_el.strings if t.strip()]
+    return ", ".join(parts) if parts else None
+
+
+def _fetch_detail(url: str) -> tuple[str | None, str | None]:
+    """Pull description and full venue address from the detail page."""
     try:
         resp = http_get_with_retry(url, headers={"User-Agent": _USER_AGENT}, timeout=15)
     except Exception as exc:
         logger.warning("City of Madison: failed to fetch detail page %s: %s", url, exc)
-        return None
+        return None, None
     soup = BeautifulSoup(resp.content, "lxml")
+
+    description: str | None = None
     body = soup.select_one(".field.body.text-with-summary")
-    if body is None:
-        return None
-    text = clean_html_text(body.get_text(" ", strip=True))
-    return text or None
+    if body is not None:
+        text = clean_html_text(body.get_text(" ", strip=True))
+        description = text or None
+
+    venue_address: str | None = None
+    addr_el = soup.select_one("address")
+    if addr_el is not None:
+        span_el = addr_el.select_one("span")
+        if span_el is not None:
+            venue_address = _parse_address_from_span(span_el)
+
+    return description, venue_address

--- a/backend/tests/test_city_of_madison.py
+++ b/backend/tests/test_city_of_madison.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from app.scrapers.city_of_madison import (
     _CENTRAL,
+    _parse_address_from_span,
     _parse_item,
     _parse_start_at,
     _parse_time_range,
@@ -226,3 +227,31 @@ class TestParseItem:
             "<time>",
         )
         assert _parse_item(_content(html)) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_address_from_span
+# ---------------------------------------------------------------------------
+
+class TestParseAddressFromSpan:
+    def test_single_line(self):
+        soup = BeautifulSoup("<span>3747 Speedway Road</span>", "lxml")
+        assert _parse_address_from_span(soup.select_one("span")) == "3747 Speedway Road"
+
+    def test_multiline_with_br(self):
+        soup = BeautifulSoup(
+            "<span>330 West Mifflin Street<br/>Madison, WI 53703-2514</span>", "lxml"
+        )
+        assert _parse_address_from_span(soup.select_one("span")) == (
+            "330 West Mifflin Street, Madison, WI 53703-2514"
+        )
+
+    def test_empty_span(self):
+        soup = BeautifulSoup("<span></span>", "lxml")
+        assert _parse_address_from_span(soup.select_one("span")) is None
+
+    def test_whitespace_only_lines_skipped(self):
+        soup = BeautifulSoup("<span>  \n  330 West Mifflin Street\n  <br/>  \n  Madison, WI 53703\n  </span>", "lxml")
+        assert _parse_address_from_span(soup.select_one("span")) == (
+            "330 West Mifflin Street, Madison, WI 53703"
+        )


### PR DESCRIPTION
## Summary

- The City of Madison scraper was extracting `venue_address` only from the events listing page, which contains just the street name (e.g. `"330 West Mifflin Street"`)
- The detail page for each event already contains the full address with city/state/zip in the same `<span>`, separated by a `<br>` element — but the scraper was ignoring it
- Fix: add `_parse_address_from_span()` helper that joins text nodes via `span.strings` (naturally handles `<br>` splits), rename `_fetch_detail_description()` → `_fetch_detail()` returning `(description, venue_address)`, and apply the full address in `fetch()` — no extra network requests

## Verification
- [x] Lint passes (`ruff check backend/`)
- [x] All 21 tests pass (`pytest backend/tests/test_city_of_madison.py`), including 4 new `TestParseAddressFromSpan` regression tests
- [x] Confirmed detail page HTML structure: `<span>330 West Mifflin Street<br/>Madison, WI 53703-2514</span>` on live site

closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)