### PR TITLE
Fix Aubergine cross-source dedup (closes #215)

### DIFF
--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -59,6 +59,18 @@ CANONICAL_VENUES: dict[str, CanonicalVenue] = {
     "king street corner of the capitol square": CanonicalVenue(
         43.0746917, -89.3841658, "Capitol Square, Madison, WI 53703"
     ),
+    # Aubergine — Willy Street Co-op community space at 1226 Williamson St.
+    # Visit Madison uses the verbose subtitle form ("Aubergine: A Willy Street
+    # Co-Op Community Space") while Isthmus uses just "Aubergine"; the alias
+    # entry normalizes the long form to "Aubergine" before hashing so both
+    # sources produce the same canonical_hash and dedup into one row (#215).
+    "aubergine": CanonicalVenue(
+        43.0840219, -89.3637186, "1226 Williamson St, Madison, WI 53703"
+    ),
+    "aubergine: a willy street co-op community space": CanonicalVenue(
+        43.0840219, -89.3637186, "1226 Williamson St, Madison, WI 53703",
+        canonical_name="Aubergine",
+    ),
     # Overture Center building names — the canonical display name is
     # "Overture Center for the Arts"; all sub-room and alias entries
     # below carry canonical_name so ingest normalizes them before hashing.

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -383,6 +383,34 @@ def test_non_canonical_venue_address_is_left_untouched(db):
 
 
 # ---------------------------------------------------------------------------
+# 9. Canonical-venue alias normalization for dedup (#215): sources that use
+#    a verbose subtitle form of a venue name ("Aubergine: A Willy Street
+#    Co-Op Community Space") must merge with sources that use the short form
+#    ("Aubergine") because both normalize to the same canonical_name before
+#    canonical_hash runs.
+# ---------------------------------------------------------------------------
+
+def test_venue_alias_normalizes_for_dedup(db):
+    ingest_events(
+        "Visit Madison",
+        [_raw(title="Story Hour", venue_name="Aubergine: A Willy Street Co-Op Community Space")],
+        db,
+    )
+    ingest_events(
+        "Isthmus",
+        [_raw(title="Story Hour", venue_name="Aubergine", source_url="https://isthmus.com/e/1")],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+    event = db.query(Event).one()
+    assert event.venue_name == "Aubergine"
+    assert event.venue_address == "1226 Williamson St, Madison, WI 53703"
+
+
+# ---------------------------------------------------------------------------
 # 9. Source-priority overwrite (#114): higher-trust source overwrites fields
 #    set by a lower-trust source; lower-trust source cannot overwrite back.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Visit Madison uses venue name `"Aubergine: A Willy Street Co-Op Community Space"` while Isthmus uses `"Aubergine"`. Because `canonical_hash` keys on venue name, these produced different hashes and the fuzzy dedup step (which requires an exact venue name match) never bridged the gap — causing both sources to create separate Event rows for the same show.
- Fix: add `"aubergine: a willy street co-op community space"` to `canonical_venues.py` with `canonical_name="Aubergine"`. `_normalize_raw_venue()` now maps the verbose form to the short form before hashing, so both sources produce the same canonical hash and are merged into one row.
- Also adds the base `"aubergine"` key with Nominatim-verified coordinates for `1226 Williamson St, Madison, WI 53703`, giving correct geocoding for all events at this venue.
- Regression test added (`test_venue_alias_normalizes_for_dedup`).

closes #215

## Verification
- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/test_ingest.py -v` — 23 passed (including new regression test)
- [x] `pytest backend/tests/ -v` — 380 passed, no regressions