### PR TITLE
Fix Holy Wisdom Monastery cross-source dedup (closes #216)

### DIFF
--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -71,6 +71,17 @@ CANONICAL_VENUES: dict[str, CanonicalVenue] = {
         43.0840219, -89.3637186, "1226 Williamson St, Madison, WI 53703",
         canonical_name="Aubergine",
     ),
+    # Holy Wisdom Monastery — Isthmus iCal LOCATION ships "Holy Wisdom Monastery,
+    # Middleton" (name + city suffix) while Visit Madison uses just "Holy Wisdom
+    # Monastery". The alias entry normalizes the city-suffixed form to the bare name
+    # before hashing so both sources produce the same canonical_hash (#216).
+    "holy wisdom monastery": CanonicalVenue(
+        43.1218569, -89.4493683, "4200 County Road M, Middleton, WI 53562"
+    ),
+    "holy wisdom monastery, middleton": CanonicalVenue(
+        43.1218569, -89.4493683, "4200 County Road M, Middleton, WI 53562",
+        canonical_name="Holy Wisdom Monastery",
+    ),
     # Overture Center building names — the canonical display name is
     # "Overture Center for the Arts"; all sub-room and alias entries
     # below carry canonical_name so ingest normalizes them before hashing.

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -411,6 +411,37 @@ def test_venue_alias_normalizes_for_dedup(db):
 
 
 # ---------------------------------------------------------------------------
+# 10. City-suffix venue alias normalization for dedup (#216): Isthmus ships
+#     "Holy Wisdom Monastery, Middleton" (name + city) while Visit Madison
+#     ships "Holy Wisdom Monastery"; the alias maps the city-suffixed form to
+#     the bare name so both sources produce the same canonical_hash.
+# ---------------------------------------------------------------------------
+
+def test_city_suffix_venue_alias_normalizes_for_dedup(db):
+    ingest_events(
+        "Visit Madison",
+        [_raw(title="Kids on the Prairie", venue_name="Holy Wisdom Monastery")],
+        db,
+    )
+    ingest_events(
+        "Isthmus",
+        [_raw(
+            title="Kids on the Prairie",
+            venue_name="Holy Wisdom Monastery, Middleton",
+            source_url="https://isthmus.com/e/1",
+        )],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+    event = db.query(Event).one()
+    assert event.venue_name == "Holy Wisdom Monastery"
+    assert event.venue_address == "4200 County Road M, Middleton, WI 53562"
+
+
+# ---------------------------------------------------------------------------
 # 9. Source-priority overwrite (#114): higher-trust source overwrites fields
 #    set by a lower-trust source; lower-trust source cannot overwrite back.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Isthmus iCal LOCATION ships `"Holy Wisdom Monastery, Middleton"` (name + city) while Visit Madison ships `"Holy Wisdom Monastery"` (bare name)
- Different `venue_name` strings → different `canonical_hash` → exact dedup misses; `_fuzzy_find_event` also requires exact venue name match, so fuzzy step never bridged the gap either
- Fix: add `"holy wisdom monastery, middleton"` to `canonical_venues.py` with `canonical_name="Holy Wisdom Monastery"` so `_normalize_raw_venue()` maps the alias to the bare name before hashing — both sources then produce the same hash and merge into one `Event` row

Same class of problem as #215 (Aubergine).

## Verification
- [x] Lint passes (`ruff check backend/`)
- [x] All 381 tests pass, including new regression test `test_city_suffix_venue_alias_normalizes_for_dedup`
- [x] Aubergine test (`test_venue_alias_normalizes_for_dedup`) still passes

closes #216