### PR TITLE
Fix Isthmus end_at == start_at when DTEND absent (closes #210)

### DIFF
--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -265,6 +265,8 @@ def _parse_ical(
         start_at = _to_aware_datetime(comp.get("DTSTART").dt)
         dtend = comp.get("DTEND")
         end_at = _to_aware_datetime(dtend.dt) if dtend else None
+        if end_at is not None and end_at == start_at:
+            end_at = None
 
         raw_location = comp.get("LOCATION")
         venue_name = str(raw_location).strip() or None if raw_location else None

--- a/backend/tests/test_isthmus.py
+++ b/backend/tests/test_isthmus.py
@@ -1,7 +1,10 @@
 """Unit tests for isthmus.py detail-page extraction helpers."""
+from datetime import date
+from unittest.mock import patch
+
 from bs4 import BeautifulSoup
 
-from app.scrapers.isthmus import _CATEGORY_MAP, _extract_categories
+from app.scrapers.isthmus import _CATEGORY_MAP, _extract_categories, _parse_ical
 
 
 def _soup(html: str) -> BeautifulSoup:
@@ -68,6 +71,62 @@ class TestExtractCategories:
             </div>
         """
         assert _extract_categories(_soup(html)) == []
+
+
+_MINIMAL_SOUP = BeautifulSoup("<html><body></body></html>", "lxml")
+
+# Shared URL / date values for _parse_ical tests.
+# between() needs start < end to include the event date (same start==end returns nothing).
+_TEST_START = date(2026, 5, 15)
+_TEST_END = date(2026, 5, 17)
+_TEST_URL = "https://isthmus.com/events/test-event/?occ_dtstart=2026-05-16T19:00"
+_TEST_URL_MAP: dict = {("test event", "2026-05-16", ""): _TEST_URL}
+_TEST_TITLE_DATE_MAP: dict = {("test event", "2026-05-16"): _TEST_URL}
+
+_ICAL_NO_DTEND = b"""BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20260516T190000
+SUMMARY:Test Event
+END:VEVENT
+END:VCALENDAR"""
+
+_ICAL_WITH_DTEND = b"""BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+DTSTART;TZID=America/Chicago:20260516T190000
+DTEND;TZID=America/Chicago:20260516T210000
+SUMMARY:Test Event
+END:VEVENT
+END:VCALENDAR"""
+
+
+class TestParseIcal:
+    def test_no_dtend_yields_null_end_at(self):
+        # recurring_ical_events fills DTEND=DTSTART when the feed has no DTEND;
+        # _parse_ical must treat that zero-duration result as end_at=None.
+        with patch("app.scrapers.isthmus._fetch_detail_soup", return_value=_MINIMAL_SOUP), \
+             patch("time.sleep"):
+            events = _parse_ical(
+                _TEST_START, _TEST_END,
+                _TEST_URL_MAP, _TEST_TITLE_DATE_MAP,
+                ical_content=_ICAL_NO_DTEND,
+            )
+        assert len(events) == 1
+        assert events[0].end_at is None
+
+    def test_explicit_dtend_preserved(self):
+        # When an event has a real end time, it must survive the fix.
+        with patch("app.scrapers.isthmus._fetch_detail_soup", return_value=_MINIMAL_SOUP), \
+             patch("time.sleep"):
+            events = _parse_ical(
+                _TEST_START, _TEST_END,
+                _TEST_URL_MAP, _TEST_TITLE_DATE_MAP,
+                ical_content=_ICAL_WITH_DTEND,
+            )
+        assert len(events) == 1
+        assert events[0].end_at is not None
+        assert events[0].end_at != events[0].start_at
 
 
 class TestCategoryMap:


### PR DESCRIPTION
## Summary

- `recurring_ical_events` always synthesizes `DTEND = DTSTART` for zero-duration events (those with no explicit `DTEND` in the feed), so the existing `if dtend else None` guard in `_parse_ical` never triggered — `dtend` was never `None`
- Events lacking an explicit end time were stored as `end_at == start_at`, causing the same timestamp to appear twice on event cards
- Fix: after converting `dtend`, null out `end_at` when it equals `start_at` (semantically equivalent to no end time)

closes #210

## Verification

- [x] Lint (`ruff check backend/`) passes
- [x] Full test suite (375 tests) passes
- [x] Two new regression tests added to `test_isthmus.py`: one confirming absent DTEND → `end_at=None`, one confirming explicit DTEND is preserved
- [x] Targeted Isthmus scrape (5-day window) confirms 0 events with `end_at == start_at`; 14 of 18 events on 2026-05-17 correctly have `end_at: null`, 4 with real end times are preserved
- [ ] Confirm Isthmus event cards in the browser no longer show the same time twice for events with no explicit end time