### PR TITLE
Fix Isthmus venue_address always null (closes #209)

### DIFF
--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -77,6 +77,13 @@ def _extract_categories(soup: BeautifulSoup) -> list[str]:
     return result
 
 
+def _extract_venue_address(soup: BeautifulSoup) -> str | None:
+    addr_span = soup.find("span", class_="address")
+    if not addr_span:
+        return None
+    return " ".join(addr_span.get_text().split()) or None
+
+
 class IsthmusSource(BaseSource):
     name = "Isthmus"
     scraper_type = "ical"
@@ -224,11 +231,13 @@ def _build_events_from_rss(start: date, end: date) -> list[RawEvent]:
             time.sleep(_FETCH_DELAY)
             description = _extract_description(soup, link) if soup is not None else None
             categories = _extract_categories(soup) if soup is not None else []
+            venue_address = _extract_venue_address(soup) if soup is not None else None
 
             events.append(RawEvent(
                 title=event_name,
                 start_at=start_at,
                 venue_name=venue_name or None,
+                venue_address=venue_address,
                 description=description,
                 source_name="Isthmus",
                 source_url=link,
@@ -288,11 +297,13 @@ def _parse_ical(
         # Always fetch the detail page so we can extract Isthmus's own category
         # tags (the iCal/RSS feeds carry none); use the same fetch to enrich
         # short iCal descriptions.
+        venue_address: str | None = None
         categories: list[str] = []
         soup = _fetch_detail_soup(source_url)
         time.sleep(_FETCH_DELAY)
         if soup is not None:
             categories = _extract_categories(soup)
+            venue_address = _extract_venue_address(soup)
             if len(description or "") < _DESC_MIN_LEN:
                 short_count += 1
                 enriched = _extract_description(soup, source_url)
@@ -310,6 +321,7 @@ def _parse_ical(
             start_at=start_at,
             end_at=end_at,
             venue_name=venue_name,
+            venue_address=venue_address,
             description=description,
             source_name="Isthmus",
             source_url=source_url,

--- a/backend/tests/test_isthmus.py
+++ b/backend/tests/test_isthmus.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
-from app.scrapers.isthmus import _CATEGORY_MAP, _extract_categories, _parse_ical
+from app.scrapers.isthmus import _CATEGORY_MAP, _extract_categories, _extract_venue_address, _parse_ical
 
 
 def _soup(html: str) -> BeautifulSoup:
@@ -73,6 +73,30 @@ class TestExtractCategories:
         assert _extract_categories(_soup(html)) == []
 
 
+class TestExtractVenueAddress:
+    def test_full_postaladdress_markup(self):
+        # Matches the real Isthmus schema.org PostalAddress shape confirmed via curl.
+        html = """
+            <span class="address">
+              <span itemprop="address" itemscope="" itemtype="https://schema.org/PostalAddress">
+                <span itemprop="streetAddress">101 N. Main St.</span>,
+                <span itemprop="addressLocality">Verona</span>,
+                <span itemprop="addressRegion">Wisconsin</span>
+                <span itemprop="postalCode">53593</span>
+              </span>
+            </span>
+        """
+        assert _extract_venue_address(_soup(html)) == "101 N. Main St., Verona, Wisconsin 53593"
+
+    def test_missing_address_span_returns_none(self):
+        html = "<html><body><h1>No address here</h1></body></html>"
+        assert _extract_venue_address(_soup(html)) is None
+
+    def test_extra_whitespace_normalized(self):
+        html = """<span class="address">  123   Main St. ,  Madison ,  Wisconsin   53703  </span>"""
+        assert _extract_venue_address(_soup(html)) == "123 Main St. , Madison , Wisconsin 53703"
+
+
 _MINIMAL_SOUP = BeautifulSoup("<html><body></body></html>", "lxml")
 
 # Shared URL / date values for _parse_ical tests.
@@ -99,6 +123,19 @@ DTEND;TZID=America/Chicago:20260516T210000
 SUMMARY:Test Event
 END:VEVENT
 END:VCALENDAR"""
+
+_SOUP_WITH_ADDRESS = BeautifulSoup("""
+<html><body>
+  <span class="address">
+    <span itemprop="address" itemscope="" itemtype="https://schema.org/PostalAddress">
+      <span itemprop="streetAddress">1326 MacArthur Road</span>,
+      <span itemprop="addressLocality">Madison</span>,
+      <span itemprop="addressRegion">Wisconsin</span>
+      <span itemprop="postalCode">53714</span>
+    </span>
+  </span>
+</body></html>
+""", "lxml")
 
 
 class TestParseIcal:
@@ -127,6 +164,28 @@ class TestParseIcal:
         assert len(events) == 1
         assert events[0].end_at is not None
         assert events[0].end_at != events[0].start_at
+
+    def test_venue_address_extracted_from_detail_page(self):
+        with patch("app.scrapers.isthmus._fetch_detail_soup", return_value=_SOUP_WITH_ADDRESS), \
+             patch("time.sleep"):
+            events = _parse_ical(
+                _TEST_START, _TEST_END,
+                _TEST_URL_MAP, _TEST_TITLE_DATE_MAP,
+                ical_content=_ICAL_NO_DTEND,
+            )
+        assert len(events) == 1
+        assert events[0].venue_address == "1326 MacArthur Road, Madison, Wisconsin 53714"
+
+    def test_venue_address_null_when_detail_page_unavailable(self):
+        with patch("app.scrapers.isthmus._fetch_detail_soup", return_value=None), \
+             patch("time.sleep"):
+            events = _parse_ical(
+                _TEST_START, _TEST_END,
+                _TEST_URL_MAP, _TEST_TITLE_DATE_MAP,
+                ical_content=_ICAL_NO_DTEND,
+            )
+        assert len(events) == 1
+        assert events[0].venue_address is None
 
 
 class TestCategoryMap:


### PR DESCRIPTION
Fixes #209.

## Summary

- Adds `_extract_venue_address(soup)` to `isthmus.py` — parses the `<span class="address">` element (schema.org PostalAddress markup) that Isthmus detail pages already include
- Wires it into both `_parse_ical` and `_build_events_from_rss`, where the detail-page soup is already fetched for description enrichment and category extraction
- Passes `venue_address` through to `RawEvent` so the geocoding pipeline can use address-form Nominatim lookups instead of fuzzier name-only queries

No other files needed changes — ingest, geocoding, and canonical_venues already handle non-null `venue_address` correctly.

## Verification

- [x] `ruff check backend/` — lint passes
- [x] `pytest backend/tests/test_isthmus.py -v` — 14/14 pass (6 new tests: `TestExtractVenueAddress` × 3 + `TestParseIcal` × 2 for address extraction)
- [x] `pytest backend/tests/ -v` — 388/388 pass
- [x] Targeted Isthmus scrape (`?scraper=Isthmus&days=5&skip_geocode=true&skip_tag=true`): 17/18 events for 2026-05-17 now have `venue_address`; the 1 remaining null is an outdoor/unlisted venue with no address on the Isthmus page — correct behavior