### PR TITLE
Fix Orpheum Theater venue-name dedup when Visit Madison prefixes "The" (closes #223)

### DIFF
--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -49,6 +49,18 @@ CANONICAL_VENUES: dict[str, CanonicalVenue] = {
     "orpheum theatre": CanonicalVenue(
         43.0751848, -89.3887320, "216 State St, Madison, WI 53703"
     ),
+    # Visit Madison ships "The Orpheum Theater" (with leading "The") while
+    # Ticketmaster ships "Orpheum Theater". These aliases normalize the "The"
+    # prefix form so both sources produce the same venue_name before hashing
+    # and fuzzy dedup (#223).
+    "the orpheum theater": CanonicalVenue(
+        43.0751848, -89.3887320, "216 State St, Madison, WI 53703",
+        canonical_name="Orpheum Theater",
+    ),
+    "the orpheum theatre": CanonicalVenue(
+        43.0751848, -89.3887320, "216 State St, Madison, WI 53703",
+        canonical_name="Orpheum Theater",
+    ),
     "barrymore theatre": CanonicalVenue(
         43.0930640, -89.3522665, "2090 Atwood Ave, Madison, WI 53704"
     ),

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -442,6 +442,60 @@ def test_city_suffix_venue_alias_normalizes_for_dedup(db):
 
 
 # ---------------------------------------------------------------------------
+# 10b. "The" prefix venue alias for Orpheum (#223): Visit Madison ships
+#      "The Orpheum Theater" while Ticketmaster ships "Orpheum Theater".
+#      The alias in canonical_venues normalizes the "The" form before hashing
+#      so fuzzy dedup can find a venue match and merge the two events.
+# ---------------------------------------------------------------------------
+
+def test_orpheum_the_prefix_venue_alias_merges(db):
+    vm_title = "Joe Jackson"
+    tm_title = "Joe Jackson + Band - Hope and Fury Tour 2026"
+    start = datetime(2026, 5, 22, 20, 0, 0, tzinfo=timezone.utc)
+
+    ingest_events(
+        "Visit Madison",
+        [_raw(title=vm_title, venue_name="The Orpheum Theater", start_at=start)],
+        db,
+    )
+    ingest_events(
+        "Ticketmaster",
+        [_raw(
+            title=tm_title,
+            venue_name="Orpheum Theater",
+            start_at=start,
+            source_url="https://www.ticketmaster.com/event/xyz",
+        )],
+        db,
+    )
+
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+    # Reverse direction: Ticketmaster first, Visit Madison second — also merges.
+    db.query(EventSource).delete()
+    db.query(Event).delete()
+    db.commit()
+    ingest_events(
+        "Ticketmaster",
+        [_raw(title=tm_title, venue_name="Orpheum Theater", start_at=start)],
+        db,
+    )
+    ingest_events(
+        "Visit Madison",
+        [_raw(
+            title=vm_title,
+            venue_name="The Orpheum Theater",
+            start_at=start,
+            source_url="https://www.visitmadison.com/event/joe-jackson/74824/",
+        )],
+        db,
+    )
+    assert db.query(Event).count() == 1
+    assert db.query(EventSource).count() == 2
+
+
+# ---------------------------------------------------------------------------
 # 9. Source-priority overwrite (#114): higher-trust source overwrites fields
 #    set by a lower-trust source; lower-trust source cannot overwrite back.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Visit Madison ships `venue_name = "The Orpheum Theater"` (Simpleview `location` field); Ticketmaster ships `"Orpheum Theater"` (Discovery API `venue.name`). The leading "The" was absent from `CANONICAL_VENUES`, so `_normalize_raw_venue` left it unchanged.
- In `_fuzzy_find_event` the candidate query filters on an exact lowercase venue match, so the two strings never collided — events were inserted as separate rows despite identical start time and a title where one is a substring of the other.
- Fix: adds `"the orpheum theater"` and `"the orpheum theatre"` alias entries with `canonical_name="Orpheum Theater"`, following the same pattern as Aubergine and Holy Wisdom Monastery. After normalization both sources produce `"Orpheum Theater"`, the venue filter finds the candidate, and the existing title-substring check merges them.

## Verification
- [x] `ruff check backend/` — lint clean
- [x] New regression test `test_orpheum_the_prefix_venue_alias_merges` covers both ingestion orders (VM→TM and TM→VM)
- [x] Full test suite: 376 passed

closes #223