### PR TITLE
Fix Isthmus description image-caption leakage (closes #211)

### DIFF
--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -55,6 +55,12 @@ def _extract_description(soup: BeautifulSoup, url: str) -> str | None:
     if not content:
         logger.warning("No id='content' element at %s", url)
         return None
+    # Isthmus's hero image card (div.single.media-carousel) injects
+    # "× Expand <photographer-credit> <event-title>" into the visible text,
+    # which then prefixes every description on events with a hero image.
+    # Drop it (and any generic <figure>) before extracting paragraph text.
+    for node in content.select("div.media-carousel, figure"):
+        node.decompose()
     return clean_html_text(content.get_text()) or None
 
 

--- a/backend/tests/test_isthmus.py
+++ b/backend/tests/test_isthmus.py
@@ -4,7 +4,13 @@ from unittest.mock import patch
 
 from bs4 import BeautifulSoup
 
-from app.scrapers.isthmus import _CATEGORY_MAP, _extract_categories, _extract_venue_address, _parse_ical
+from app.scrapers.isthmus import (
+    _CATEGORY_MAP,
+    _extract_categories,
+    _extract_description,
+    _extract_venue_address,
+    _parse_ical,
+)
 
 
 def _soup(html: str) -> BeautifulSoup:
@@ -71,6 +77,64 @@ class TestExtractCategories:
             </div>
         """
         assert _extract_categories(_soup(html)) == []
+
+
+class TestExtractDescription:
+    def test_strips_media_carousel_image_caption(self):
+        # Mirrors the real Jim Erickson page (issue #211): the hero image
+        # card is a div.single.media-carousel containing the "× Expand",
+        # photographer credit, and image alt text. Without stripping, all of
+        # that text prefixes the actual blurb in p.lead.
+        html = """
+            <html><body>
+              <div id="content">
+                <div>
+                  <div class="single media-carousel">× Expand Laurie Lang Jim Erickson</div>
+                  <p class="lead">Jazz, 5:30 pm Saturdays. Free.</p>
+                </div>
+              </div>
+            </body></html>
+        """
+        result = _extract_description(_soup(html), "https://example.test/jim")
+        assert result == "Jazz, 5:30 pm Saturdays. Free."
+        assert "× Expand" not in result
+        assert "Laurie Lang" not in result
+
+    def test_preserves_full_text_when_no_carousel(self):
+        # Longer-form events (e.g. Kids on the Prairie) have no media-carousel
+        # and several paragraphs of body copy. The strip must be a no-op there.
+        html = """
+            <html><body>
+              <div id="content">
+                <div>
+                  <p class="lead">Lead paragraph with the intro blurb.</p>
+                  <p>Second paragraph with more detail about the event.</p>
+                  <p>Third paragraph with logistics.</p>
+                </div>
+              </div>
+            </body></html>
+        """
+        result = _extract_description(_soup(html), "https://example.test/long")
+        assert "Lead paragraph with the intro blurb." in result
+        assert "Second paragraph with more detail about the event." in result
+        assert "Third paragraph with logistics." in result
+
+    def test_strips_generic_figure_node(self):
+        # Forward safety: if Isthmus ever swaps the media-carousel div for a
+        # standard <figure> layout, the strip should still drop it.
+        html = """
+            <html><body>
+              <div id="content">
+                <div>
+                  <figure><img src="x.jpg" alt="Show photo"><figcaption>Photo: Alice</figcaption></figure>
+                  <p>Actual description body.</p>
+                </div>
+              </div>
+            </body></html>
+        """
+        result = _extract_description(_soup(html), "https://example.test/fig")
+        assert result == "Actual description body."
+        assert "Photo: Alice" not in result
 
 
 class TestExtractVenueAddress:


### PR DESCRIPTION
## Summary
- Fixes #211: Isthmus events with a hero image had their descriptions prefixed with `× Expand <photographer> <event title>` because `_extract_description` called `get_text()` over the whole `#content` block, which includes Isthmus's hero image card (`div.single.media-carousel`).
- `backend/app/scrapers/isthmus.py::_extract_description` now decomposes `div.media-carousel` and any generic `<figure>` inside `#content` before extracting text.
- Added `TestExtractDescription` in `backend/tests/test_isthmus.py` with three cases: the real Jim Erickson media-carousel shape, a multi-paragraph event without a carousel (no-op), and a generic figure node.

## Why no backfill
`ingest.py`'s `is_self_rerun_at_top` path (already in place) overwrites all `_OVERWRITABLE_FIELDS` — including `description` — on re-ingest from the same source when that source is the top contributor on the row. The next scheduled Isthmus scrape heals the polluted rows automatically; no SQL backfill required.

## Verification
- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/test_isthmus.py -v` — 17 passed (3 new)
- [x] `pytest backend/` — 378 passed
- [x] Direct check on saved Jim Erickson HTML: cleaned description starts with `"Jazz, 5:30 pm Saturdays."` with no `× Expand` or `Laurie Lang`
- [x] Live `POST /admin/scrape?scraper=Isthmus&days=7&skip_geocode=true&skip_tag=true` against local docker stack; checked 7 dates (2026-05-17 → 2026-05-23, 92 Isthmus events total) — `× Expand` leakage count: **0** (down from 9 on 2026-05-17 alone in prod)
- [ ] After merge + Fly.io auto-deploy, verify next scheduled Isthmus scrape heals the polluted rows in prod (grep API descriptions for `× Expand` on 2026-05-17/18 — expect 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)