### PR TITLE
Fix DMI scraper: strip trailing 'REGISTRATION: Loading…' widget placeholder

### DIFF
--- a/backend/app/scrapers/dmi.py
+++ b/backend/app/scrapers/dmi.py
@@ -31,6 +31,13 @@ _METRO_CITIES: frozenset[str] = frozenset({
 })
 _MADISON_ZIP_RE = re.compile(r"\b537\d{2}\b")
 
+# Tribe Events registration widgets emit "REGISTRATION:\n\nLoading…" when JS
+# hasn't hydrated the widget server-side. Strip it when it's the trailing content.
+_TRAILING_REGISTRATION_RE = re.compile(
+    r"\s*REGISTRATION:\s*\n+\s*(?:Loading[…\.]{0,3}|Please\s+wait[…\.]{0,3})\s*$",
+    re.IGNORECASE,
+)
+
 
 class DMISource(BaseSource):
     name = "DMI"
@@ -154,7 +161,9 @@ def _parse_event(doc: dict) -> RawEvent | None:
         if end_at is not None and end_at.date() == start_at.date():
             end_at = None
 
-    description = clean_html_text(doc.get("description") or "") or None
+    raw_desc = clean_html_text(doc.get("description") or "")
+    raw_desc = _TRAILING_REGISTRATION_RE.sub("", raw_desc).strip()
+    description = raw_desc or None
 
     # Same entity-decoding issue as the title — the DMI feed ships venue names
     # like "RDG Planning &#038; Design" raw. Decode so the card and the canonical

--- a/backend/tests/test_dmi.py
+++ b/backend/tests/test_dmi.py
@@ -187,6 +187,40 @@ class TestParseEvent:
         assert ev.all_day is True
         assert ev.end_at is None
 
+    def test_description_trailing_loading_unicode_stripped(self):
+        # Real-world: Tribe Events registration widget leaves "REGISTRATION:\n\nLoading…"
+        # when JS hasn't hydrated. Strip it; preserve the descriptive copy above.
+        doc = _base_doc(description="<p>Join us!</p><h2>REGISTRATION:</h2><p>Loading…</p>")
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert ev.description == "Join us!"
+
+    def test_description_trailing_loading_dots_stripped(self):
+        doc = _base_doc(description="<p>Join us!</p><h2>REGISTRATION:</h2><p>Loading...</p>")
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert ev.description == "Join us!"
+
+    def test_description_trailing_please_wait_stripped(self):
+        doc = _base_doc(description="<p>Details here.</p><h2>REGISTRATION:</h2><p>Please wait…</p>")
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert ev.description == "Details here."
+
+    def test_description_registration_no_sentinel_preserved(self):
+        # "REGISTRATION:" alone (no loading sentinel) is kept — we can't confirm it's broken.
+        doc = _base_doc(description="<p>Join us!</p><h2>REGISTRATION:</h2>")
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert "REGISTRATION:" in (ev.description or "")
+
+    def test_description_registration_mid_content_preserved(self):
+        # "REGISTRATION:" mid-description with real content following is not touched.
+        doc = _base_doc(description="<p>Join us!</p><h2>REGISTRATION:</h2><p>Sign up at eventbrite.com/e/12345</p>")
+        ev = _parse_event(doc)
+        assert ev is not None
+        assert "eventbrite.com" in (ev.description or "")
+
     def test_missing_title_returns_none(self):
         assert _parse_event(_base_doc(title="")) is None
 


### PR DESCRIPTION
## Summary

- DMI event descriptions sourced from the Tribe Events API sometimes end with a bare `REGISTRATION:\n\nLoading…` block — the unhydrated placeholder of a JS-rendered registration widget (Eventbrite or similar) that hasn't run when the scraper fetches server-side
- Added `_TRAILING_REGISTRATION_RE` to `backend/app/scrapers/dmi.py`, applied after `clean_html_text`, that strips this trailing block when the only content after `REGISTRATION:` is a recognized loading sentinel (`Loading…`, `Loading...`, `Please wait…`, etc.)
- The filter requires the sentinel — bare `REGISTRATION:` headings followed by real content are preserved unchanged

## Verification

- [x] Lint (`ruff check backend/`) — clean
- [x] Full test suite (`pytest backend/tests/`) — 388/388 passed
- [x] New regression tests: Unicode ellipsis stripped, ASCII dots stripped, "Please wait" stripped, bare `REGISTRATION:` with no sentinel preserved, mid-description `REGISTRATION:` with real content preserved

closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)