### PR TITLE
Fix Delta Beer Lab venue_address showing Madison instead of Fitchburg (closes #229)

### DIFF
--- a/backend/app/canonical_venues.py
+++ b/backend/app/canonical_venues.py
@@ -34,6 +34,12 @@ CANONICAL_VENUES: dict[str, CanonicalVenue] = {
     "high noon saloon": CanonicalVenue(
         43.0797191, -89.3762962, "701 E Washington Ave, Madison, WI 53703"
     ),
+    # Our Lives stores city="Madison" for Delta Beer Lab; the correct postal
+    # city is Fitchburg (#229). Canonical entry corrects both the displayed
+    # address and the geocoder lookup.
+    "delta beer lab": CanonicalVenue(
+        43.0373542, -89.3823463, "167 E Badger Rd, Fitchburg, WI 53713"
+    ),
     "atwood music hall": CanonicalVenue(
         43.0909400, -89.3556544, "1925 Winnebago St, Madison, WI 53704"
     ),

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -371,6 +371,20 @@ def test_canonical_venue_address_corrected_on_subsequent_run(db):
     assert event.venue_address == "701 E Washington Ave, Madison, WI 53703"
 
 
+def test_delta_beer_lab_fitchburg_address_corrected_on_insert(db):
+    # Our Lives ships city="Madison" for Delta Beer Lab; the canonical registry
+    # corrects it to Fitchburg (#229).
+    raw = _raw(
+        title="Pairs Jigsaw Puzzle Contest",
+        venue_name="Delta Beer Lab",
+        venue_address="167 E Badger Rd, Madison, WI 53713",
+        source_name="Our Lives",
+    )
+    ingest_events("Our Lives", [raw], db)
+    event = db.query(Event).one()
+    assert event.venue_address == "167 E Badger Rd, Fitchburg, WI 53713"
+
+
 def test_non_canonical_venue_address_is_left_untouched(db):
     raw = _raw(
         venue_name="Some Random Bar",


### PR DESCRIPTION
## Summary

- Our Lives' Tribe Events calendar stores `city="Madison"` for Delta Beer Lab (167 E Badger Rd, ZIP 53713), but the correct postal city is Fitchburg, WI. The scraper faithfully read that field, so `venue_address` was ingested as `167 E Badger Rd, Madison, WI 53713` instead of `167 E Badger Rd, Fitchburg, WI 53713`.
- Adds `"delta beer lab"` to `CANONICAL_VENUES` in `canonical_venues.py` with Nominatim-verified coordinates and the correct Fitchburg address. The existing `_apply_canonical_address` in `ingest.py` already handles overwriting the address on insert/update — no ingest changes needed.
- The canonical entry also short-circuits the geocoder so future geocode passes use the registry coordinates rather than a Nominatim lookup anchored to the wrong city.

## Verification

- [x] Lint (`ruff check backend/`) — all checks passed
- [x] Full test suite (384 tests) — all passed
- [x] New regression test `test_delta_beer_lab_fitchburg_address_corrected_on_insert` passes
- [x] Docker stack started, targeted Our Lives scrape triggered (`?scraper=Our+Lives&days=7&skip_geocode=true&skip_tag=true`) — all 4 Delta Beer Lab events in the DB show `venue_address = '167 E Badger Rd, Fitchburg, WI 53713'`

closes #229