### PR TITLE
Fix scrape cascade: rollback session between sources

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -178,6 +178,12 @@ def trigger_scrape(
         except Exception as e:
             results[s.name] = {"error": str(e)}
             logger.warning("Scrape failed: %s — %s", s.name, e)
+            # Clear any pending/invalid transaction state so the next scraper
+            # gets a usable session. Without this, a mid-ingest DB error (e.g.
+            # an SSL connection drop) leaves the session unusable and every
+            # subsequent scraper fails with "Can't reconnect until invalid
+            # transaction is rolled back".
+            db.rollback()
             continue
         if days is not None and not s.supports_window_days:
             # Surface the no-op so a caller passing ?days=N knows the filter
@@ -192,6 +198,7 @@ def trigger_scrape(
         except Exception as e:
             results[s.name]["geocode_error"] = str(e)
             logger.warning("Geocode failed: %s — %s", s.name, e)
+            db.rollback()
     if not skip_tag:
         try:
             results["_tagging"] = tag_untagged_events(db)


### PR DESCRIPTION
## Summary
- Add `db.rollback()` in the per-scraper `except` blocks in `trigger_scrape` so a mid-ingest DB error (e.g. an SSL connection drop) doesn't poison the shared SQLAlchemy session and cascade into every subsequent scraper.

## Why
Today's daily scrape ([run 26038930934](https://github.com/linuxmaier/whats-up-madison/actions/runs/26038930934)) had Isthmus fail with `SSL connection has been closed unexpectedly` ~44 minutes in. After that, Visit Madison, City of Madison, and Alliant Energy Center all failed with `Can't reconnect until invalid transaction is rolled back` — the request-scoped session was left in an invalid state by Isthmus and every following scraper hit the same wall before it could query the DB.

The deeper problem — Isthmus taking ~50 min and the overall pipeline being fragile/sequential — is tracked in #238. This PR is just the narrow safety net so one bad source can't sink the others.

## Test plan
- [x] `ruff check backend/` passes
- [x] `pytest backend/tests/` passes (419 tests)
- [ ] On next daily run, confirm a single-source failure no longer cascades (post-deploy observation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)