### PR TITLE
Chunk scraper ingestion to keep DB connections warm

### DIFF
--- a/backend/app/ingest.py
+++ b/backend/app/ingest.py
@@ -29,8 +29,23 @@ _OVERWRITABLE_FIELDS = ("title", "description", "start_at", "end_at", "venue_nam
 FUZZY_TITLE_THRESHOLD = 0.65  # tuned empirically against the Isthmus + Visit Madison overlap
 
 
-def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> dict:
-    run_start = datetime.now(timezone.utc)
+def ingest_chunk(
+    source_name: str,
+    raw_events: list[RawEvent],
+    db: Session,
+    *,
+    run_start: datetime,
+) -> dict:
+    """Insert/update one batch of raw events from ``source_name``.
+
+    Commits at the end. Does NOT deactivate stale rows or mark events removed
+    — those passes belong in :func:`finalize_source_run` and only run after
+    the full set of chunks for a source has been processed. The split lets
+    scrapers with long per-event fetch phases (Isthmus) yield events
+    incrementally: each chunk commits while later chunks are still being
+    built, keeping the DB connection warm and persisting partial progress
+    when a later batch fails.
+    """
     inserted = 0
     updated = 0
 
@@ -46,13 +61,16 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
     # same title/date/venue). They produce one Event row, so we must produce
     # one EventSource row too — otherwise the (event_id, source_name) unique
     # constraint trips. We keep the first occurrence and union categories from
-    # the rest.
+    # the rest. Scoped to the chunk: two raws in different chunks with the
+    # same hash collide on the DB lookup instead (the first commit makes the
+    # EventSource visible to the second chunk's query).
     raw_events = _dedupe_by_hash(raw_events)
 
     # Tracks event_ids for which we've already created/updated an EventSource
-    # for source_name in this run. Needed because fuzzy matching can map two
+    # for source_name in this chunk. Needed because fuzzy matching can map two
     # distinct raws (different canonical_hashes) to the same Event row, which
-    # would otherwise produce a duplicate (event_id, source_name) insert.
+    # would otherwise produce a duplicate (event_id, source_name) insert
+    # before the next db.flush() makes the first add visible.
     seen_for_source: set = set()
 
     for raw in raw_events:
@@ -168,10 +186,29 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
                 source.is_active = True
             seen_for_source.add(event.id)
 
-    # Flush pending EventSource inserts so the cleanup queries below can see them
     db.flush()
+    db.commit()
 
-    # Deactivate EventSources from this scraper that weren't seen in this run
+    stats = {"inserted": inserted, "updated": updated}
+    logger.info("%s ingest chunk: %s", source_name, stats)
+    return stats
+
+
+def finalize_source_run(
+    source_name: str,
+    db: Session,
+    *,
+    run_start: datetime,
+) -> dict:
+    """Run end-of-source cleanup after all chunks for ``source_name`` complete.
+
+    Deactivates ``EventSource`` rows from this source that weren't touched
+    (``last_seen_at < run_start``) and marks events with no remaining active
+    sources as ``removed``. Skip this when a chunk raised — without a full
+    pass we can't confidently distinguish "source dropped this event" from
+    "we never got to it before the failure," so the safe default is to leave
+    EventSource rows alone and let the next clean run reconcile.
+    """
     deactivated = (
         db.query(EventSource)
         .filter(
@@ -182,7 +219,6 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
         .update({"is_active": False}, synchronize_session=False)
     )
 
-    # Mark events with no remaining active sources as removed
     active_event_ids = (
         select(EventSource.event_id).where(EventSource.is_active.is_(True))
     )
@@ -193,9 +229,23 @@ def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> 
 
     db.commit()
 
-    stats = {"inserted": inserted, "updated": updated, "deactivated": deactivated}
-    logger.info("%s ingest: %s", source_name, stats)
+    stats = {"deactivated": deactivated}
+    logger.info("%s finalize: %s", source_name, stats)
     return stats
+
+
+def ingest_events(source_name: str, raw_events: list[RawEvent], db: Session) -> dict:
+    """Single-batch convenience wrapper around ingest_chunk + finalize.
+
+    Preserves the original API for tests and any caller that still passes a
+    full list at once. New code should drive the chunked path directly via
+    ``fetch_chunks()`` → ``ingest_chunk()`` → ``finalize_source_run()`` so
+    long-running scrapers don't sit on an idle DB connection.
+    """
+    run_start = datetime.now(timezone.utc)
+    chunk_stats = ingest_chunk(source_name, raw_events, db, run_start=run_start)
+    final_stats = finalize_source_run(source_name, db, run_start=run_start)
+    return {**chunk_stats, **final_stats}
 
 
 def _normalize_title_for_match(title: str) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 import logging.config
 
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Optional
 
 import httpx
@@ -12,7 +13,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.database import Base, engine, get_db
 from app.geocode_runner import geocode_all_missing, geocode_missing_for_source
-from app.ingest import ingest_events
+from app.ingest import finalize_source_run, ingest_chunk
 from app.routers import events
 from app.schemas import FeedbackRequest
 from app.scrapers.alliant import AlliantEnergyCenterSource
@@ -170,13 +171,25 @@ def trigger_scrape(
             "Starting scrape: %s (window_days=%s, skip_geocode=%s, skip_tag=%s)",
             s.name, days, skip_geocode, skip_tag,
         )
+        run_start = datetime.now(timezone.utc)
+        totals = {"inserted": 0, "updated": 0}
         try:
-            raw = s.fetch(window_days=days)
-            stats = ingest_events(s.name, raw, db)
-            results[s.name] = stats
-            logger.info("Scrape complete: %s — %s", s.name, stats)
+            for chunk in s.fetch_chunks(window_days=days):
+                cs = ingest_chunk(s.name, chunk, db, run_start=run_start)
+                totals["inserted"] += cs["inserted"]
+                totals["updated"] += cs["updated"]
+            # Only run the deactivation/removed-marking sweep on a fully
+            # successful pass. If fetch_chunks raised partway through, we
+            # can't distinguish "source dropped this event" from "we never
+            # got to it," so we leave EventSource rows untouched and the
+            # next clean run reconciles. Partial chunks already committed
+            # by ingest_chunk stay — that's the win over the all-or-nothing
+            # behavior we had before.
+            totals.update(finalize_source_run(s.name, db, run_start=run_start))
+            results[s.name] = totals
+            logger.info("Scrape complete: %s — %s", s.name, totals)
         except Exception as e:
-            results[s.name] = {"error": str(e)}
+            results[s.name] = {**totals, "error": str(e)}
             logger.warning("Scrape failed: %s — %s", s.name, e)
             # Clear any pending/invalid transaction state so the next scraper
             # gets a usable session. Without this, a mid-ingest DB error (e.g.

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -2,6 +2,7 @@ import hashlib
 import html
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
@@ -85,3 +86,15 @@ class BaseSource:
 
     def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         raise NotImplementedError
+
+    def fetch_chunks(self, window_days: int | None = None) -> Iterator[list[RawEvent]]:
+        """Yield batches of events as they become available.
+
+        The orchestrator ingests each batch immediately, so scrapers whose
+        fetch phase is long (per-event detail fetches with rate limiting)
+        keep the DB connection warm and persist partial progress if a later
+        batch fails. The default implementation yields one batch containing
+        the full fetch() result — appropriate for fast scrapers where there
+        is no natural chunk boundary.
+        """
+        yield self.fetch(window_days=window_days)

--- a/backend/app/scrapers/isthmus.py
+++ b/backend/app/scrapers/isthmus.py
@@ -2,6 +2,7 @@ import logging
 import re
 import time
 import xml.etree.ElementTree as ET
+from collections.abc import Iterator
 from datetime import date, datetime, timedelta
 from urllib.parse import parse_qs, urlparse
 from zoneinfo import ZoneInfo
@@ -136,26 +137,53 @@ class IsthmusSource(BaseSource):
     # (stale rescheduled events).
     scraper_type = "rss"
 
-    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
+    def _window(self, window_days: int | None) -> tuple[date, date]:
         # Use Central time, not the container's clock — backend runs in UTC, so
         # date.today() returns tomorrow's date after ~7 PM Central, cutting off
         # today's events from the scrape window.
         today = datetime.now(_CENTRAL).date()
         end_date = today + timedelta(days=window_days if window_days is not None else _WINDOW_DAYS)
+        return today, end_date
+
+    def fetch(self, window_days: int | None = None) -> list[RawEvent]:
         # Open a short-lived session for the detail-page cache. Kept local to
         # this scraper rather than threaded through BaseSource.fetch — Isthmus
         # is the only scraper today that needs persistence inside fetch(), and
         # mixing the cache writes into the orchestrator's request-scoped
         # session would re-couple the two (which #239 just decoupled).
+        today, end_date = self._window(window_days)
         db = SessionLocal()
         try:
             return _build_events_from_rss(today, end_date, db=db)
         finally:
             db.close()
 
+    def fetch_chunks(self, window_days: int | None = None) -> Iterator[list[RawEvent]]:
+        """Yield one batch of RawEvents per RSS page.
 
-def _build_events_from_rss(start: date, end: date, *, db: Session | None = None) -> list[RawEvent]:
-    """Walk the paginated RSS feed and build RawEvents.
+        Each page covers ~50 occurrences and finishes its detail-page fetches
+        in ~25s (0.5s courtesy delay × ~50 cache misses on a cold cache), so
+        the orchestrator's DB session sees writes that often instead of
+        sitting idle for ~17 min while the full feed is walked. The cache and
+        the per-source DB session are independent: this generator owns a
+        ``SessionLocal`` for the ``isthmus_details`` cache; the orchestrator's
+        ``db`` is the one that takes the ingest writes.
+        """
+        today, end_date = self._window(window_days)
+        db = SessionLocal()
+        try:
+            yield from _iter_event_pages_from_rss(today, end_date, db=db)
+        finally:
+            db.close()
+
+
+def _iter_event_pages_from_rss(
+    start: date,
+    end: date,
+    *,
+    db: Session | None = None,
+) -> Iterator[list[RawEvent]]:
+    """Walk the paginated RSS feed yielding one RawEvent batch per page.
 
     Each <item> is one pre-expanded occurrence (recurring events emit one item
     per date). The link/guid carries `occ_dtstart` with the local start
@@ -172,7 +200,7 @@ def _build_events_from_rss(start: date, end: date, *, db: Session | None = None)
     # from this module).
     from app.scrapers.isthmus_cache import compute_rss_signature, get_or_fetch_detail
 
-    events: list[RawEvent] = []
+    total_events = 0
     short_count = enriched_count = failed_count = 0
     cache_hits = cache_misses = 0
     page = 1
@@ -185,6 +213,7 @@ def _build_events_from_rss(start: date, end: date, *, db: Session | None = None)
         if not items:
             break
 
+        page_events: list[RawEvent] = []
         all_beyond_window = True
         for item in items:
             link = item.findtext("link") or ""
@@ -259,7 +288,7 @@ def _build_events_from_rss(start: date, end: date, *, db: Session | None = None)
                     short_count += 1
                     failed_count += 1
 
-            events.append(RawEvent(
+            page_events.append(RawEvent(
                 title=event_name,
                 start_at=start_at,
                 end_at=end_at,
@@ -272,6 +301,10 @@ def _build_events_from_rss(start: date, end: date, *, db: Session | None = None)
                 categories=categories,
             ))
 
+        total_events += len(page_events)
+        if page_events:
+            yield page_events
+
         if all_beyond_window:
             break
         page += 1
@@ -283,5 +316,17 @@ def _build_events_from_rss(start: date, end: date, *, db: Session | None = None)
         )
     if db is not None:
         logger.info("Isthmus detail cache: %d hit, %d miss", cache_hits, cache_misses)
-    logger.info("Isthmus: built %d events from RSS", len(events))
+    logger.info("Isthmus: built %d events from RSS", total_events)
+
+
+def _build_events_from_rss(start: date, end: date, *, db: Session | None = None) -> list[RawEvent]:
+    """Flatten ``_iter_event_pages_from_rss`` into a single list.
+
+    Kept for the back-compat ``IsthmusSource.fetch()`` path and the unit
+    tests that exercise the feed parser directly. New callers should drive
+    the generator and ingest each page as it arrives.
+    """
+    events: list[RawEvent] = []
+    for page in _iter_event_pages_from_rss(start, end, db=db):
+        events.extend(page)
     return events


### PR DESCRIPTION
## Summary

- Generalizes scraper ingestion to a chunked interface: `BaseSource.fetch_chunks` yields `list[RawEvent]` batches; default impl wraps `fetch()` as one chunk so the ten non-Isthmus scrapers need no changes.
- Splits `ingest.py` into `ingest_chunk` (per-batch insert/update/fuzzy/merge, commits per call) and `finalize_source_run` (deactivation sweep + "no remaining sources → removed" cleanup). `ingest_events` stays as a thin wrapper for tests and back-compat.
- Updates the `/admin/scrape` loop to iterate `fetch_chunks`, accumulate per-source totals, and run finalize only on a clean pass. A mid-iteration failure now leaves chunks committed and skips the deactivation sweep, instead of dropping the whole source.
- Refactors `IsthmusSource` to yield one batch per RSS page (~50 events ≈ ~25s of detail-page work on a cold cache) so the orchestrator's DB session sees writes every ~30s instead of after ~17min.

## Why

Yesterday's 17:31 daily scrape failed with `psycopg2.OperationalError: SSL connection has been closed unexpectedly` mid-Isthmus, after `_build_events_from_rss` returned 1512 events and the first DB read inside `ingest_events` hit the long-idle connection. All 1512 Isthmus events were dropped. The curl trigger in `.github/workflows/scrape.yml` also tripped its `--max-time 1800` ceiling even though the server completed ~7min later.

Chunking fixes both: the connection stays warm (no long idle gap) and any partial progress is captured on failure instead of lost.

## Test plan

- [x] `ruff check backend/` — clean
- [x] `pytest backend/tests/` — 424 passed
- [x] Local docker compose smoke test: cold-cache Isthmus run committed 8 chunks at 30–60s intervals, finalize deactivated 86 stale rows, response totals reconciled (`198 + 16 + 86`).
- [x] Idempotent re-run on warm cache finished in ~15s: 0 inserts / 211 updates / 0 deactivations, cache 215 hits / 0 misses.
- [ ] Next daily scrape (or `workflow_dispatch`) succeeds within the curl timeout and Isthmus reports a normal insert/update/deactivate row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)