### PR TITLE
Re-enable daily scraping and alarm on stale production data (closes #244)

### DIFF
--- a/.github/scripts/check_freshness.sh
+++ b/.github/scripts/check_freshness.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fail if production hasn't ingested events recently.
+#
+# The Daily Scrape stopping is otherwise silent — GET /events keeps serving the
+# last successful ingest, so the site looks fine while quietly showing week-old
+# data. That is exactly what happened in #244: GitHub disabled the scheduled
+# workflow after 60 days of repo inactivity and nothing surfaced it.
+#
+# Env:
+#   HEALTH_URL     health endpoint to poll (required)
+#   MAX_AGE_HOURS  fail above this ingest age (default 48)
+set -euo pipefail
+
+HEALTH_URL="${HEALTH_URL:?HEALTH_URL is required}"
+MAX_AGE_HOURS="${MAX_AGE_HOURS:-48}"
+
+# fly.toml runs with min_machines_running = 0, so the first request can time out
+# while the machine cold-starts. Retry before concluding anything is wrong.
+response=""
+for attempt in 1 2 3 4 5; do
+  if response=$(curl -fsS --max-time 30 "$HEALTH_URL" 2>/dev/null); then
+    break
+  fi
+  echo "attempt $attempt: $HEALTH_URL not reachable yet, retrying..."
+  response=""
+  sleep 10
+done
+
+if [ -z "$response" ]; then
+  echo "FAIL: $HEALTH_URL unreachable after 5 attempts."
+  exit 1
+fi
+
+echo "$response"
+
+database=$(echo "$response" | jq -r '.database // "missing"')
+if [ "$database" != "ok" ]; then
+  echo "FAIL: health reports database=$database"
+  exit 1
+fi
+
+age=$(echo "$response" | jq -r '.hours_since_ingest // "null"')
+if [ "$age" = "null" ]; then
+  echo "FAIL: health reports no ingest has ever run (last_ingest_at is null)."
+  exit 1
+fi
+
+# jq handles the float comparison; bash can't compare decimals.
+if [ "$(jq -n --argjson a "$age" --argjson m "$MAX_AGE_HOURS" '$a > $m')" = "true" ]; then
+  cat <<EOF
+FAIL: production last ingested ${age}h ago, over the ${MAX_AGE_HOURS}h threshold.
+
+The Daily Scrape has probably stopped. Check whether GitHub disabled it:
+
+  gh api repos/linuxmaier/whats-up-madison/actions/workflows \\
+    --jq '.workflows[] | .name + "  " + .state'
+
+A state of 'disabled_inactivity' means it was auto-disabled after 60 days of
+repo inactivity. Re-enable and kick off a run:
+
+  gh api -X PUT repos/linuxmaier/whats-up-madison/actions/workflows/<id>/enable
+  gh workflow run scrape.yml
+EOF
+  exit 1
+fi
+
+echo "OK: production last ingested ${age}h ago (threshold ${MAX_AGE_HOURS}h)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Drives the `freshness` job below. A schedule alone would be no good — GitHub
+  # disables scheduled triggers repo-wide after 60 days of inactivity, which is
+  # exactly the failure this job exists to catch, so it would go quiet at the
+  # same moment the scrape did. The push trigger is the durable half.
+  schedule:
+    - cron: '0 16 * * *'  # 11am CT, ~3h after the Daily Scrape
 
 jobs:
   lint:
@@ -43,6 +49,26 @@ jobs:
           python-version: "3.12"
       - run: pip install -r backend/requirements.txt
       - run: pytest backend/tests/ -v
+
+  # Production data going stale is invisible from the outside: /events keeps
+  # serving the last successful ingest. GitHub silently disabled the Daily
+  # Scrape workflow after 60 days of repo inactivity and production froze for a
+  # week before it was noticed (#244). This turns that into a red job.
+  #
+  # Deliberately NOT in any `needs:` list — stale production data must never
+  # block shipping the fix for stale production data.
+  freshness:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check production ingest freshness
+        run: ./.github/scripts/check_freshness.sh
+        env:
+          # fly.toml sets min_machines_running = 0, so the first request may
+          # cold-start the machine; the script retries before failing.
+          HEALTH_URL: https://whats-up-madison.fly.dev/health
+          MAX_AGE_HOURS: "48"
 
   deploy:
     needs: [lint, frontend-lint, test]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,45 @@ curl -X POST 'http://localhost:8000/admin/scrape?scraper=Isthmus&days=3&skip_geo
 
 To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost:8000/admin/geocode'` (add `?force=true` to clear non-success cache rows and retry previously-failed lookups).
 
+## Scheduled scraping
+
+`.github/workflows/scrape.yml` POSTs `/admin/scrape` against production daily at 8am CT (`cron: '0 13 * * *'`), authenticated with the `ADMIN_API_KEY` secret. It's also `workflow_dispatch`-able: `gh workflow run scrape.yml`.
+
+### The silent failure mode (#244)
+
+**GitHub disables scheduled workflows after 60 days of repository inactivity, and tells you nothing.** This bit us: the last commit before a quiet stretch was 2026-05-19, the last successful scrape was 2026-07-18 — exactly 60 days later — and production served week-old data until someone happened to notice an event on the wrong date.
+
+Nothing about it is visible from the outside. `GET /events` keeps serving the last successful ingest, so the site looks healthy while quietly going stale. The workflow just stops appearing in `gh run list`.
+
+To check:
+
+```
+gh api repos/linuxmaier/whats-up-madison/actions/workflows --jq '.workflows[] | .name + "  " + .state'
+```
+
+`state=disabled_inactivity` means it was auto-disabled. Re-enable and kick off a run:
+
+```
+gh api -X PUT repos/linuxmaier/whats-up-madison/actions/workflows/<id>/enable
+gh workflow run scrape.yml
+```
+
+A stale row left behind by a missed scrape **self-heals** once scraping resumes — the staleness sweep in `finalize_source_run` deactivates the untouched `EventSource` and flips the event to `status='removed'`. No manual cleanup needed. That's why #244's wrong-date row needed no code fix.
+
+### Freshness monitoring
+
+Two pieces turn the silent freeze into a loud one:
+
+- **`GET /health`** reports `last_ingest_at`, `hours_since_ingest`, `active_events`, and `database`. The DB query is wrapped so an outage returns 200 with `database: "unavailable"` and null fields rather than a 500 — the endpoint doubles as a liveness probe and must not take the app down.
+- **The `freshness` job in `ci.yml`** runs `.github/scripts/check_freshness.sh`, which polls production `/health` and fails when `hours_since_ingest` exceeds 48 or the database is unreachable.
+
+Two deliberate choices in that job:
+
+- It runs on **`push` to main as well as on a schedule**. A schedule-only checker would share the exact weakness it's guarding against — it would be disabled at the same moment the scrape was. The push trigger is the durable half.
+- It is **not in any `needs:` list** and doesn't gate `deploy`. Stale production data must never block shipping the fix for stale production data.
+
+The script retries with backoff because `min_machines_running = 0` in `backend/fly.toml` means the first request can cold-start the machine.
+
 ## Current Build Status
 
 - **Done (Step 1):** repo skeleton, Docker Compose, PostgreSQL, SQLAlchemy models, FastAPI `GET /events?date=` endpoint, scraper base class.
@@ -305,7 +344,8 @@ To backfill or retry geocoding outside a scrape: `curl -X POST 'http://localhost
 - **Done (Step 5):** geocoding pipeline (Nominatim, cached per venue in `venue_geocodes`) runs after each scraper; `latitude`/`longitude` exposed on the API; List/Map segmented toggle in the header renders a Leaflet map of Madison with clustered pins, multi-event popups, and a panel for events whose venues didn't resolve.
 - **Done (recent polish):** fuzzy cross-source dedup in ingest (title similarity ≥ 0.65 anchored by time + venue); explicit source priority ranking (`SOURCE_PRIORITY` in `frontend/src/lib/sources.js`); Isthmus description enrichment from event detail pages; Isthmus detail-page extractions cached in `isthmus_details` keyed by URL (with `occ_dtstart` stripped) and refreshed only when the RSS-visible name / venue / description changes — see `backend/app/scrapers/isthmus_cache.py`; Previous/Next nav buttons; sticky-header layout fixes.
 - **Done (CI/CD):** backend auto-deploys to Fly.io on push to main via the `deploy` job in `.github/workflows/ci.yml` — runs after lint + tests pass, only when `backend/**` files changed. Frontend auto-deploys to Cloudflare Workers on every push to main (Cloudflare's built-in CI). Requires `FLY_API_TOKEN` GitHub secret (Fly.io deploy token).
-- **In progress (Step 3):** eleven scrapers integrated — Isthmus (paginated RSS — was iCal + RSS through #231; dropped iCal because RSS covers ~7x more events for the same window and was the source of #210/#228), Visit Madison (Simpleview JSON API), High Noon Saloon (HTML calendar), Our Lives (Tribe Events REST), Ticketmaster (Discovery API, multi-venue: Sylvee, Orpheum, Kohl Center, etc.), Atwood Music Hall (Squarespace events collection — also surfaces sister-venue shows at Barrymore Theatre + Liquid), Majestic Theatre (HTML calendar, same FPC Live theme as High Noon; ranked above Ticketmaster in `SOURCE_PRIORITY` because the venue site's `Event Description` section is materially richer than TM's boilerplate-dominated `info`/`pleaseNote`), DMI (Downtown Madison Inc., Tribe Events REST on `downtownmadison.org` filtered to the `dmi-events` category — public-facing DMI events like What's Up Downtown, New Faces New Places, the I.D.E.A. Series, Behind The Scenes, and the Annual Celebration; small but high-signal civic source with zero overlap with other aggregators), Wisconsin Chamber Orchestra (Craft-CMS site at `wcoconcerts.org`, `GET /load/events` AJAX endpoint returns the upcoming WCO slate — the six free Concerts on the Square outdoor evenings on the Capitol Square plus indoor series at Hamel Music Center and Overture Center; pre-tagged `Music`, detail-page enriched for show copy, venue em-dash compounds normalized to room names so Overture sub-rooms merge via canonical-venues), City of Madison (official municipal events at `cityofmadison.com/events` — Drupal 10 server-rendered HTML; paginates `?page=N` with a browser-like UA required by the site WAF; 30-day window; detail-page description enrichment; high signal for parks programming, civic meetings, and community events not covered by entertainment aggregators), Alliant Energy Center (`alliantenergycenter.com/upcoming-events` — DotNetNuke server-rendered HTML, single GET returns ~16 events spanning ~2.5 months; expo / agricultural / civic content not covered by other sources: The Madison Classic Horse Show, FFA Convention, Dane County Fair, Red Angus Junior National Show, autocross, scrapbook conventions, HS graduations; calendar is dates-only — no event times — so ranked **last** in `SOURCE_PRIORITY` to keep time-bearing sources authoritative on shared events while still null-filling multi-day `end_at` on events like Visit Madison's Brat Fest; canonical-venue aliases for Isthmus's `Alliant Energy Center-Exhibition Hall` and Visit Madison's `Willow Island at Alliant Energy Center` collapse to the building name before hashing). The Overture Center scraper was shipped but deprecated in #162 after we confirmed Imperva blocks all `*.overture.org` paths from Fly.io's IP range; canonical-venue normalization still tags Isthmus/Ticketmaster/WCO events at Overture correctly. All but High Noon, Atwood, Majestic, and WCO use a 30-day forward window; those four pull whatever the venue has posted (typically several to ~15 months). More candidate sources in `docs/EVENT_SOURCES.md`; daily scheduling not yet wired up (no APScheduler — recommend running `/admin/scrape` from cron / systemd timer / external scheduler).
+- **Done (scheduling):** `.github/workflows/scrape.yml` POSTs `/admin/scrape` daily at 8am CT. See *Scheduled scraping* below — **the schedule has a silent failure mode you need to know about.**
+- **In progress (Step 3):** eleven scrapers integrated — Isthmus (paginated RSS — was iCal + RSS through #231; dropped iCal because RSS covers ~7x more events for the same window and was the source of #210/#228), Visit Madison (Simpleview JSON API), High Noon Saloon (HTML calendar), Our Lives (Tribe Events REST), Ticketmaster (Discovery API, multi-venue: Sylvee, Orpheum, Kohl Center, etc.), Atwood Music Hall (Squarespace events collection — also surfaces sister-venue shows at Barrymore Theatre + Liquid), Majestic Theatre (HTML calendar, same FPC Live theme as High Noon; ranked above Ticketmaster in `SOURCE_PRIORITY` because the venue site's `Event Description` section is materially richer than TM's boilerplate-dominated `info`/`pleaseNote`), DMI (Downtown Madison Inc., Tribe Events REST on `downtownmadison.org` filtered to the `dmi-events` category — public-facing DMI events like What's Up Downtown, New Faces New Places, the I.D.E.A. Series, Behind The Scenes, and the Annual Celebration; small but high-signal civic source with zero overlap with other aggregators), Wisconsin Chamber Orchestra (Craft-CMS site at `wcoconcerts.org`, `GET /load/events` AJAX endpoint returns the upcoming WCO slate — the six free Concerts on the Square outdoor evenings on the Capitol Square plus indoor series at Hamel Music Center and Overture Center; pre-tagged `Music`, detail-page enriched for show copy, venue em-dash compounds normalized to room names so Overture sub-rooms merge via canonical-venues), City of Madison (official municipal events at `cityofmadison.com/events` — Drupal 10 server-rendered HTML; paginates `?page=N` with a browser-like UA required by the site WAF; 30-day window; detail-page description enrichment; high signal for parks programming, civic meetings, and community events not covered by entertainment aggregators), Alliant Energy Center (`alliantenergycenter.com/upcoming-events` — DotNetNuke server-rendered HTML, single GET returns ~16 events spanning ~2.5 months; expo / agricultural / civic content not covered by other sources: The Madison Classic Horse Show, FFA Convention, Dane County Fair, Red Angus Junior National Show, autocross, scrapbook conventions, HS graduations; calendar is dates-only — no event times — so ranked **last** in `SOURCE_PRIORITY` to keep time-bearing sources authoritative on shared events while still null-filling multi-day `end_at` on events like Visit Madison's Brat Fest; canonical-venue aliases for Isthmus's `Alliant Energy Center-Exhibition Hall` and Visit Madison's `Willow Island at Alliant Energy Center` collapse to the building name before hashing). The Overture Center scraper was shipped but deprecated in #162 after we confirmed Imperva blocks all `*.overture.org` paths from Fly.io's IP range; canonical-venue normalization still tags Isthmus/Ticketmaster/WCO events at Overture correctly. All but High Noon, Atwood, Majestic, and WCO use a 30-day forward window; those four pull whatever the venue has posted (typically several to ~15 months). More candidate sources in `docs/EVENT_SOURCES.md`.
 
 Backend: http://localhost:8000 — API docs: http://localhost:8000/docs
 Frontend: http://localhost:5173

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,10 +8,12 @@ from typing import Optional
 import httpx
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.database import Base, engine, get_db
+from app.models import Event, EventSource
 from app.geocode_runner import geocode_all_missing, geocode_missing_for_source
 from app.ingest import finalize_source_run, ingest_chunk
 from app.routers import events
@@ -101,9 +103,43 @@ def require_admin_key(x_admin_key: Optional[str] = Header(default=None)):
         raise HTTPException(status_code=401, detail="Invalid or missing X-Admin-Key")
 
 
+# A scrape that stops running is invisible from the outside — /events keeps
+# serving whatever was last ingested. GitHub silently disabled the Daily Scrape
+# workflow for 60 days of repo inactivity and production went stale for a week
+# before anyone noticed (#244). These fields give the CI freshness check
+# something to alarm on.
 @app.get("/health")
-def health():
-    return {"status": "ok"}
+def health(db: Session = Depends(get_db)):
+    payload: dict = {"status": "ok", "database": "ok"}
+    try:
+        last_ingest = db.query(func.max(EventSource.last_seen_at)).scalar()
+        payload["active_events"] = (
+            db.query(func.count(Event.id)).filter(Event.status == "active").scalar()
+        )
+    except Exception as exc:  # noqa: BLE001 - report degradation, don't crash the probe
+        logger.warning("Health check could not reach the database: %s", exc)
+        return {
+            "status": "ok",
+            "database": "unavailable",
+            "last_ingest_at": None,
+            "hours_since_ingest": None,
+            "active_events": None,
+        }
+
+    if last_ingest is None:
+        payload["last_ingest_at"] = None
+        payload["hours_since_ingest"] = None
+        return payload
+
+    # Rows written before the column carried tzinfo come back naive; assume UTC
+    # so the subtraction below can't raise.
+    if last_ingest.tzinfo is None:
+        last_ingest = last_ingest.replace(tzinfo=timezone.utc)
+    payload["last_ingest_at"] = last_ingest.isoformat()
+    payload["hours_since_ingest"] = round(
+        (datetime.now(timezone.utc) - last_ingest).total_seconds() / 3600, 2
+    )
+    return payload
 
 
 @app.post("/feedback")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,102 @@
+"""Tests for the /health freshness fields (#244).
+
+A scrape that stops running is invisible from the outside — GET /events keeps
+serving the last successful ingest, so the site looks fine while quietly showing
+week-old data. That is what happened in #244: GitHub disabled the Daily Scrape
+workflow after 60 days of repo inactivity and production froze for a week.
+These fields give the CI freshness check something to alarm on.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database import get_db
+from app.ingest import ingest_events
+from app.main import app
+from app.models import EventSource
+from app.scrapers.base import RawEvent
+
+
+@pytest.fixture
+def client(db):
+    def _override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _raw(title: str = "Concert in the Park") -> RawEvent:
+    return RawEvent(
+        title=title,
+        start_at=datetime(2026, 6, 15, 19, 0, 0, tzinfo=timezone.utc),
+        source_name="Source A",
+        source_url=f"https://example.com/{title.replace(' ', '-')}",
+        venue_name="Garner Park",
+    )
+
+
+def test_health_reports_no_ingest_on_an_empty_database(client):
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["database"] == "ok"
+    assert body["last_ingest_at"] is None
+    assert body["hours_since_ingest"] is None
+    assert body["active_events"] == 0
+
+
+def test_health_reports_a_fresh_ingest(client, db):
+    ingest_events("Source A", [_raw()], db)
+
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["database"] == "ok"
+    assert body["active_events"] == 1
+    assert body["last_ingest_at"] is not None
+    # Just ingested, so effectively zero hours old.
+    assert 0 <= body["hours_since_ingest"] < 1
+
+
+def test_health_reports_a_stale_ingest(client, db):
+    # The #244 scenario: the scraper stopped a week ago. The events still serve
+    # fine; only last_seen_at reveals that nothing has run.
+    ingest_events("Source A", [_raw()], db)
+    stale = datetime.now(timezone.utc) - timedelta(days=7)
+    db.query(EventSource).update({"last_seen_at": stale}, synchronize_session=False)
+    db.commit()
+
+    body = client.get("/health").json()
+    assert body["status"] == "ok"
+    assert body["active_events"] == 1
+    # ~168h — comfortably past the 48h CI threshold.
+    assert body["hours_since_ingest"] > 48
+
+
+def test_health_stays_200_when_the_database_is_unreachable():
+    # The endpoint doubles as a liveness probe, so a database outage must
+    # degrade the payload rather than 500 the request.
+    class _BrokenSession:
+        def query(self, *args, **kwargs):
+            raise RuntimeError("connection refused")
+
+    def _override_get_db():
+        yield _BrokenSession()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        resp = TestClient(app).get("/health")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["database"] == "unavailable"
+    assert body["last_ingest_at"] is None
+    assert body["hours_since_ingest"] is None
+    assert body["active_events"] is None

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -385,6 +385,39 @@ def test_staleness_deactivates_and_removes(db):
 # 6. Reactivation: removed event reappears → status back to active
 # ---------------------------------------------------------------------------
 
+def test_wrong_date_row_self_heals_on_the_next_run(db):
+    # The #244 scenario. Production held "First Friday Open Mic" on 2026-08-14
+    # while the source lists Aug 7. The listing page and parser were both
+    # correct — the row was stale, left behind because the Daily Scrape had been
+    # disabled for a week. Once scraping resumes, the staleness sweep retires
+    # the wrong-date row and the correct one ingests alongside it.
+    wrong = _raw(
+        title="First Friday Open Mic",
+        start_at=datetime(2026, 8, 14, 15, 0, 0, tzinfo=timezone.utc),
+        venue_name="Madison Senior Center",
+        source_name="City of Madison",
+    )
+    ingest_events("City of Madison", [wrong], db)
+    assert db.query(Event).filter_by(status="active").count() == 1
+
+    # Next run: the source only returns the correct Aug 7 occurrence.
+    corrected = _raw(
+        title="First Friday Open Mic",
+        start_at=datetime(2026, 8, 7, 15, 0, 0, tzinfo=timezone.utc),
+        venue_name="Madison Senior Center",
+        source_name="City of Madison",
+    )
+    ingest_events("City of Madison", [corrected], db)
+
+    active = db.query(Event).filter_by(status="active").all()
+    assert len(active) == 1
+    assert active[0].start_at == datetime(2026, 8, 7, 15, 0, 0, tzinfo=timezone.utc)
+
+    removed = db.query(Event).filter_by(status="removed").all()
+    assert len(removed) == 1
+    assert removed[0].start_at == datetime(2026, 8, 14, 15, 0, 0, tzinfo=timezone.utc)
+
+
 def test_reactivation(db):
     ingest_events("Source A", [_raw()], db)
     ingest_events("Source A", [], db)


### PR DESCRIPTION
closes #244

## The reported bug wasn't the bug

#244 said production showed `First Friday Open Mic` on 2026-08-14 while the source lists Aug 7, with Aug 7 missing entirely. I filed it during #236 with the root cause unresolved, guessing at a `<li>` → date-widget pairing bug in the City of Madison scraper.

**That guess was wrong.** Investigation found:

- The listing page is **correct** — `First Friday Open Mic` carries `2026-08-07`; `Friday Open Stage` carries `07-31` and `08-14`.
- The **current parser reads it correctly**. Running the real `_parse_item` over 11 saved listing pages (109 events) yields Aug 7. Every `<li>` holds exactly one `.event-content`, so the pairing hypothesis doesn't hold, and page ordering is strictly non-decreasing, so the `done` early-exit isn't truncating anything.
- **GitHub had disabled the Daily Scrape workflow** with `state=disabled_inactivity` — auto-disabled after 60 days of repo inactivity. Last commit 2026-05-19, last successful scrape 2026-07-18. Exactly 60 days.

Production had been **frozen for a week**. That also explains why it was still serving pre-#248 venue names. The Aug 14 row was stale data, and the staleness sweep in `finalize_source_run` retires it as soon as scraping resumes — **no parser change was warranted.**

## What this PR adds

The freeze was completely silent. `GET /events` keeps serving the last successful ingest, so the site looks healthy while quietly going stale — the only symptom was one event on a wrong date, spotted by chance. This makes it loud:

**`GET /health`** now reports `last_ingest_at`, `hours_since_ingest`, `active_events` and `database`. The DB query is wrapped so an outage returns **200** with `database: "unavailable"` and null fields rather than a 500 — the endpoint doubles as a liveness probe and must not take the app down.

**`.github/scripts/check_freshness.sh`** polls `/health` and fails when the ingest is older than 48h or the database is unreachable, printing the `gh` commands to diagnose and re-enable a disabled schedule. It retries with backoff because `min_machines_running = 0` in `fly.toml` means the first request can cold-start the machine.

**A `freshness` job in `ci.yml`.** Two deliberate choices:

- Runs on **`push` to main as well as on a schedule**. A schedule-only checker would share the exact weakness it guards against — GitHub disables schedules repo-wide on inactivity, so it would go quiet at the same moment the scrape did. The push trigger is the durable half.
- **Not in any `needs:` list**, and doesn't gate `deploy`. Stale production data must never block shipping the fix for stale production data.

## Verification

- [x] `ruff check backend/` clean
- [x] `pytest backend/tests/` — 465 pass; CI `lint`, `frontend-lint`, `test` all green
- [x] New `test_health.py` covers empty-database, fresh, stale (>48h) and database-unreachable payloads
- [x] `test_ingest.py` gains a test naming the #244 self-heal: a wrong-date row is retired to `status='removed'` once the source returns the corrected occurrence
- [x] **The check can actually go red** — verified against synthetic payloads: fresh → exit 0; stale 168h → exit 1; `database: unavailable` → exit 1; never-ingested → exit 1, each with an actionable message
- [x] **Local end-to-end** — seeded a source into a clean stack; `/health` moved from `active_events: 0, last_ingest_at: null` to `active_events: 6, hours_since_ingest: 0.0`, and the script passes
- [x] Daily Scrape re-enabled (`state=active`) and a catch-up run triggered — **completed successfully**
- [x] **#244 confirmed fixed in production:**
  - `2026-08-07` → `First Friday Open Mic` ✅ (the correct first Friday)
  - `2026-08-14` → `Friday Open Stage` only ✅ (the spurious row is gone)
- [x] The week of blocked deploys landed too — venue now renders as `Madison Senior Center` (#248's canonical rename)

No manual checks — every signal is observable via the API, the DB, or CI.

## Two things worth knowing before you merge

**1. The `freshness` job hasn't executed yet.** It skips on `pull_request` by design, so its first real run is the push to main after merge. Production is freshly scraped, so it should pass; I'll watch it.

**2. Coordinate coverage in production is 34.6% missing**, against 16.4% measured locally for #248. That's the post-deploy step the #248 PR flagged — `POST /admin/geocode` re-attempts the previously-failed set, which the per-scrape pass doesn't clear. I have **not** run it (production write, real Nominatim spend, ~10–20 min at 1 req/sec). Say the word and I will.

## Docs

`AGENTS.md` gains a **Scheduled scraping** section documenting the `disabled_inactivity` failure mode, how to spot it, how to re-enable, and the fact that stale rows self-heal without manual cleanup. Also corrects the *Current Build Status* line, which still claimed "daily scheduling not yet wired up" despite `scrape.yml` having driven it for months.

## Filed separately

**#252** — the DMI scraper is broken. Its REST endpoint 301-redirects https→http *and* drops the query string, so DMI contributes zero events. The orchestrator swallows the per-source error, so the run still reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)