### PR TITLE
Raise daily-scrape curl timeout to 3600s (closes #263)

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -10,7 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger scrape
+        # --max-time must stay well above the slowest real run, not near it. A full
+        # pipeline medians ~18min but has been observed at 28min; at the old 1800s
+        # (30min) limit a normal bad day tripped the wall. Holding the connection
+        # open also keeps the Fly machine alive: backend/fly.toml sets
+        # auto_stop_machines='stop' with min_machines_running=0, so when curl
+        # disconnects this request is the only thing keeping the machine up and Fly
+        # autostops it a few minutes later — potentially SIGINT-ing a run mid-flight.
         run: |
           curl -f -X POST https://whats-up-madison.fly.dev/admin/scrape \
             -H "X-Admin-Key: ${{ secrets.ADMIN_API_KEY }}" \
-            --max-time 1800
+            --max-time 3600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,26 @@ gh workflow run scrape.yml
 
 A stale row left behind by a missed scrape **self-heals** once scraping resumes — the staleness sweep in `finalize_source_run` deactivates the untouched `EventSource` and flips the event to `status='removed'`. No manual cleanup needed. That's why #244's wrong-date row needed no code fix.
 
+### The curl timeout keeps the machine alive (#263)
+
+`--max-time` on the workflow's curl is **not just a client-side report deadline** — it is what holds the Fly machine up for the duration of the run. `backend/fly.toml` sets `auto_stop_machines = 'stop'` with `min_machines_running = 0`, so the CI request is the only thing keeping the machine awake during a scrape. When curl gives up, Fly sees zero in-flight requests and autostops a few minutes later, SIGINT-ing whatever is still running.
+
+#263 hit exactly this. The limit was 1800s (30min), and the run crossed it:
+
+```
+14:57:19  curl gives up, disconnects
+14:59:00  last scraper finishes          <-- 96 seconds of margin
+15:00:36  "excess capacity, autostopping machine" -> SIGINT
+```
+
+The scrape itself succeeded — `last_ingest_at` was 90 seconds *after* the timeout, and the tagging pass completed — so the only visible damage was a red CI job. But the margin was 96 seconds. A slightly longer run gets killed mid-tagging, and since `tag_untagged_events` commits per batch, that produces a **silent partial pass**, not a clean failure.
+
+Set the limit well above the slowest real run, never near it. Measured over 28 successful runs (2026-06-22 → 2026-07-25): median **18.0min**, range **14.1–28.0min**, with no upward trend (first-10 mean 18.1 vs last-10 18.7). The old 1800s sat at roughly the p100 of that distribution, so ordinary variance was enough to trip it. It's now 3600s; GitHub's default job timeout is 6h, so there's room.
+
+If durations ever climb toward the new limit, the better answers are sharding the workflow into per-source `?scraper=` calls (short requests, failures attributable to one source) or making `/admin/scrape` async with a job-status endpoint — not another bump.
+
+**A timed-out scrape job does not mean the data is stale.** Check `/health` `last_ingest_at` against the curl deadline before assuming an ingest was lost; the `freshness` job below is the authority on staleness, and it correctly stays green here because the ingest genuinely landed.
+
 ### Freshness monitoring
 
 Two pieces turn the silent freeze into a loud one:


### PR DESCRIPTION
Closes #263.

## Problem

Today's scheduled `Daily Scrape` run ([30206108212](https://github.com/linuxmaier/whats-up-madison/actions/runs/30206108212)) failed with `curl: (28) Operation timed out after 1800001 milliseconds with 0 bytes received`.

**The scrape succeeded.** Only the CI client gave up:

| Evidence | Value |
|---|---|
| curl deadline | 14:57:19Z |
| last scraper (Alliant) finished | 14:59:00Z |
| `/health` `last_ingest_at` | 14:58:50Z — *after* the timeout |
| active events | 2633 |
| untagged-with-description events | **0** across an 879-event sample (13 dates) |

## Root cause

`--max-time 1800` was set at roughly the p100 of observed runtimes. Over 28 successful runs (2026-06-22 → 2026-07-25):

```
median   18.0 min
range    14.1 – 28.0 min
first-10 mean 18.1 min
last-10  mean 18.7 min   <- no upward trend
```

Variance, not creep. The tail already reached 28.0 min on 2026-07-09; today's run crossed 30.

## Why this wasn't only cosmetic

`backend/fly.toml` sets `auto_stop_machines = 'stop'` with `min_machines_running = 0`, so the CI request is the only thing keeping the machine awake during a scrape. curl's disconnect removed it:

```
14:57:19  curl gives up, disconnects
14:59:00  last scraper finishes          <-- 96 seconds of margin
15:00:36  "excess capacity, autostopping machine" -> SIGINT
```

A slightly longer run gets SIGINT-ed mid-tagging. `tag_untagged_events` commits per batch, so that would be a **silent partial pass**, not a clean failure. The timeout withdraws the thing keeping the machine up.

## Changes

- **`.github/workflows/scrape.yml`** — `--max-time` 1800 → 3600, plus a comment recording why the value must stay clear of the slowest real run and how it couples to Fly's autostop. GitHub's default job timeout is 6h.
- **`AGENTS.md`** — new *"The curl timeout keeps the machine alive (#263)"* subsection under *Scheduled scraping*: the autostop coupling, the measured distribution, the escalation path if durations climb again, and the diagnostic note that **a timed-out scrape job does not by itself mean the data is stale** (check `last_ingest_at` against the curl deadline first).

## Not done here

Sharding into per-source `?scraper=` calls (short requests, per-source failure attribution) and making `/admin/scrape` async with a job-status endpoint (decouples from any HTTP timeout) are the better answers if durations approach 60 min. Noted in the docs; a bump is the right size of fix for a p100-set limit.

## Verification

- `ruff check backend/` — clean
- `pytest backend/tests/` — 463 passed
- `scrape.yml` re-parsed with PyYAML; `--max-time 3600` confirmed in the emitted run block
- No backend or frontend behavior changes

Note: scheduled runs stop at 07-18 and resume 07-25 via `workflow_dispatch` — a 7-day gap matching the #244 inactivity-disable signature. The workflow reads `active` now, so it appears already re-enabled by hand. Flagged as an observation from run history, not a confirmed second failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)